### PR TITLE
Lee-Enfield values updated

### DIFF
--- a/addons/main/CfgAmmo.hpp
+++ b/addons/main/CfgAmmo.hpp
@@ -78,8 +78,6 @@ class CfgAmmo {
         ACE_dragModel = 1;
         ACE_muzzleVelocities[] = {752, 765, 769}; // muzzle velocity 768 m/s at 21°C, 760 m/s at 15°C (normal conditions), in-game exactly "2440 fps (743 m/s) +/-50 fps at 30 yards (27.43 m) with a standart deviation of no more than 40 fps" - The Accurate Lee Enfield by Stephen Redgwell)
         ACE_barrelLengths[] = {508.0, 609.6, 660.4}; // barrel length 640 mm
-        airFriction = -0.00085276; // default -0.00105, ACE3 value -0.00085117 https://github.com/acemod/ACE3/blob/37daf3429dfd71a58a072d4198f094809dff66f6/extras/airFrictionAnalysis.txt#L194
-        typicalSpeed = 760; // default 755
     };
 
     class LIB_B_792x57_Ball: LIB_Bullet_base {

--- a/addons/main/CfgAmmo.hpp
+++ b/addons/main/CfgAmmo.hpp
@@ -76,7 +76,7 @@ class CfgAmmo {
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ICAO"; // ACE3 default normal conditions and better result with the Ruthberg airFriction tool
         ACE_dragModel = 1;
-        ACE_muzzleVelocities[] = {752, 765, 768}; // muzzle velocity 768 m/s at 21°C, 760 m/s at 15°C (normal conditions), in-game exactly "2440 fps (743 m/s) +/-50 fps at 30 yards (27.43 m) with a standart deviation of no more than 40 fps" - The Accurate Lee Enfield by Stephen Redgwell)
+        ACE_muzzleVelocities[] = {752, 765, 769}; // muzzle velocity 768 m/s at 21°C, 760 m/s at 15°C (normal conditions), in-game exactly "2440 fps (743 m/s) +/-50 fps at 30 yards (27.43 m) with a standart deviation of no more than 40 fps" - The Accurate Lee Enfield by Stephen Redgwell)
         ACE_barrelLengths[] = {508.0, 609.6, 660.4}; // barrel length 640 mm
         airFriction = -0.00085276; // default -0.00105, ACE3 value -0.00085117 https://github.com/acemod/ACE3/blob/37daf3429dfd71a58a072d4198f094809dff66f6/extras/airFrictionAnalysis.txt#L194
         typicalSpeed = 760; // default 755

--- a/addons/main/CfgAmmo.hpp
+++ b/addons/main/CfgAmmo.hpp
@@ -67,17 +67,19 @@ class CfgAmmo {
         ACE_barrelLengths[]={508.0, 609.6, 660.4};
     };
 	
-	class LIB_B_770x56_Ball: LIB_Bullet_base {
-        ACE_caliber=7.92;
-        ACE_bulletLength=34.366;
-        ACE_bulletMass=11.66;
-        ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[]={0.268};
-        ACE_velocityBoundaries[]={};
-        ACE_standardAtmosphere="ICAO";
-        ACE_dragModel=7;
-        ACE_muzzleVelocities[]={865, 900, 924};
-        ACE_barrelLengths[]={508.0, 609.6, 660.4};
+	class LIB_B_770x56_Ball: LIB_Bullet_base { // ACE_303_Ball https://github.com/acemod/ACE3/blob/e5a15d200f44df5fccc0bc5575d18d80b35538dd/extras/CfgAmmoReference.hpp#L412
+        ACE_caliber = 7.92; // https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page74.pdf
+        ACE_bulletLength = 31.166;
+        ACE_bulletMass = 11.275; // 174 grains
+        ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
+        ACE_ballisticCoefficients[] = {0.493};
+        ACE_velocityBoundaries[] = {};
+        ACE_standardAtmosphere = "ASM";
+        ACE_dragModel = 1;
+        ACE_muzzleVelocities[] = {748, 761, 765}; // muzzle velocity 764 m/s at 21°C, 756 m/s at 15°C (2440 fps +/-50 fps at 30 yards with a standart deviation of no more than 40 fps - The Accurate Lee Enfield by Stephen Redgwell)
+        ACE_barrelLengths[] = {508.0, 609.6, 660.4};
+        airFriction = -0.00085112; // default -0.00105, ACE3 value -0.00085117 https://github.com/acemod/ACE3/blob/37daf3429dfd71a58a072d4198f094809dff66f6/extras/airFrictionAnalysis.txt#L194
+        typicalSpeed = 761; // default 755
 	};
 	
 	class LIB_B_792x57_Ball: LIB_Bullet_base {

--- a/addons/main/CfgAmmo.hpp
+++ b/addons/main/CfgAmmo.hpp
@@ -74,12 +74,12 @@ class CfgAmmo {
         ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
         ACE_ballisticCoefficients[] = {0.493};
         ACE_velocityBoundaries[] = {};
-        ACE_standardAtmosphere = "ASM";
+        ACE_standardAtmosphere = "ICAO"; // ACE3 default normal conditions and better result with the Ruthberg airFriction tool
         ACE_dragModel = 1;
-        ACE_muzzleVelocities[] = {751, 764, 768}; // muzzle velocity 767 m/s at 21°C, 759 m/s at 15°C (normal conditions), in-game exactly "2440 fps (743 m/s) +/-50 fps at 30 yards (27.43 m) with a standart deviation of no more than 40 fps" - The Accurate Lee Enfield by Stephen Redgwell)
+        ACE_muzzleVelocities[] = {752, 765, 768}; // muzzle velocity 768 m/s at 21°C, 760 m/s at 15°C (normal conditions), in-game exactly "2440 fps (743 m/s) +/-50 fps at 30 yards (27.43 m) with a standart deviation of no more than 40 fps" - The Accurate Lee Enfield by Stephen Redgwell)
         ACE_barrelLengths[] = {508.0, 609.6, 660.4}; // barrel length 640 mm
-        airFriction = -0.000865; // default -0.00105, ACE3 value -0.00085117 https://github.com/acemod/ACE3/blob/37daf3429dfd71a58a072d4198f094809dff66f6/extras/airFrictionAnalysis.txt#L194
-        typicalSpeed = 759; // default 755
+        airFriction = -0.00085276; // default -0.00105, ACE3 value -0.00085117 https://github.com/acemod/ACE3/blob/37daf3429dfd71a58a072d4198f094809dff66f6/extras/airFrictionAnalysis.txt#L194
+        typicalSpeed = 760; // default 755
     };
 
     class LIB_B_792x57_Ball: LIB_Bullet_base {

--- a/addons/main/CfgAmmo.hpp
+++ b/addons/main/CfgAmmo.hpp
@@ -5,69 +5,69 @@ class CfgAmmo {
         ACE_caliber = 9.017;
         ACE_bulletLength = 15.494;
         ACE_bulletMass = 8.0352;
-        ACE_ammoTempMuzzleVelocityShifts[] = { -2.655,-2.547,-2.285,-2.012,-1.698,-1.28,-0.764,-0.153,0.596,1.517,2.619 };
-        ACE_ballisticCoefficients[] = { 0.165 };
+        ACE_ammoTempMuzzleVelocityShifts[] = {-2.655, -2.547, -2.285, -2.012, -1.698, -1.28, -0.764, -0.153, 0.596, 1.517, 2.619};
+        ACE_ballisticCoefficients[] = {0.165};
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
         ACE_dragModel = 1;
-        ACE_muzzleVelocities[] = { 340,370,400 };
-        ACE_barrelLengths[] = { 101.6,127,228.6 };
+        ACE_muzzleVelocities[] = {340, 370, 400};
+        ACE_barrelLengths[] = {101.6, 127, 228.6};
     };
 
     class LIB_Bullet_base;
-	class LIB_B_45ACP_Ball: LIB_Bullet_base {
+    class LIB_B_45ACP_Ball: LIB_Bullet_base {
         ACE_caliber = 11.481;
         ACE_bulletLength = 17.272;
         ACE_bulletMass = 14.904;
-        ACE_ammoTempMuzzleVelocityShifts[] = { -2.655,-2.547,-2.285,-2.012,-1.698,-1.28,-0.764,-0.153,0.596,1.517,2.619 };
-        ACE_ballisticCoefficients[] = { 0.195 };
+        ACE_ammoTempMuzzleVelocityShifts[] = {-2.655, -2.547, -2.285, -2.012, -1.698, -1.28, -0.764, -0.153, 0.596, 1.517, 2.619};
+        ACE_ballisticCoefficients[] = {0.195};
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
         ACE_dragModel = 1;
-        ACE_muzzleVelocities[] = { 230,250,285 };
-        ACE_barrelLengths[] = { 101.6,127,228.6 };
+        ACE_muzzleVelocities[] = {230, 250, 285};
+        ACE_barrelLengths[] = {101.6, 127, 228.6};
     };
-	
-	class LIB_B_762x25_Ball: LIB_Bullet_base { // Using LIB_B_762x54_Ball
+
+    class LIB_B_762x25_Ball: LIB_Bullet_base { // Using LIB_B_762x54_Ball
         ACE_caliber = 7.925;
         ACE_bulletLength = 28.956;
         ACE_bulletMass = 9.8496;
-        ACE_ammoTempMuzzleVelocityShifts[] = { -26.55,-25.47,-22.85,-20.12,-16.98,-12.8,-7.64,-1.53,5.96,15.17,26.19 };
-        ACE_ballisticCoefficients[] = { 0.4 };
+        ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.8, -7.64, -1.53, 5.96, 15.17, 26.19};
+        ACE_ballisticCoefficients[] = {0.4};
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ICAO";
         ACE_dragModel = 1;
-        ACE_muzzleVelocities[] = { 700,800,820,833 };
-        ACE_barrelLengths[] = { 406.4,508,609.6,660.4 };
+        ACE_muzzleVelocities[] = {700, 800, 820, 833};
+        ACE_barrelLengths[] = {406.4, 508, 609.6, 660.4};
     };
-    
-	class LIB_B_762x54_Ball: LIB_Bullet_base {
-        ACE_caliber=7.925;
-        ACE_bulletLength=28.956;
-        ACE_bulletMass=9.8496;
-        ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[]={0.4};
-        ACE_velocityBoundaries[]={};
-        ACE_standardAtmosphere="ICAO";
-        ACE_dragModel=1;
-        ACE_muzzleVelocities[]={700, 800, 820, 833};
-        ACE_barrelLengths[]={406.4, 508.0, 609.6, 660.4};
+
+    class LIB_B_762x54_Ball: LIB_Bullet_base {
+        ACE_caliber = 7.925;
+        ACE_bulletLength = 28.956;
+        ACE_bulletMass = 9.8496;
+        ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
+        ACE_ballisticCoefficients[] = {0.4};
+        ACE_velocityBoundaries[] = {};
+        ACE_standardAtmosphere = "ICAO";
+        ACE_dragModel = 1;
+        ACE_muzzleVelocities[] = {700, 800, 820, 833};
+        ACE_barrelLengths[] = {406.4, 508.0, 609.6, 660.4};
     };
-	
-	class LIB_B_762x63_Ball: LIB_Bullet_base {
-        ACE_caliber=7.823;
-        ACE_bulletLength=34.366;
-        ACE_bulletMass=12.312;
-        ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[]={0.268};
-        ACE_velocityBoundaries[]={};
-        ACE_standardAtmosphere="ICAO";
-        ACE_dragModel=7;
-        ACE_muzzleVelocities[]={865, 900, 924};
-        ACE_barrelLengths[]={508.0, 609.6, 660.4};
+
+    class LIB_B_762x63_Ball: LIB_Bullet_base {
+        ACE_caliber = 7.823;
+        ACE_bulletLength = 34.366;
+        ACE_bulletMass = 12.312;
+        ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
+        ACE_ballisticCoefficients[] = {0.268};
+        ACE_velocityBoundaries[] = {};
+        ACE_standardAtmosphere = "ICAO";
+        ACE_dragModel = 7;
+        ACE_muzzleVelocities[] = {865, 900, 924};
+        ACE_barrelLengths[] = {508.0, 609.6, 660.4};
     };
-	
-	class LIB_B_770x56_Ball: LIB_Bullet_base { // ACE_303_Ball https://github.com/acemod/ACE3/blob/e5a15d200f44df5fccc0bc5575d18d80b35538dd/extras/CfgAmmoReference.hpp#L412
+
+    class LIB_B_770x56_Ball: LIB_Bullet_base { // ACE_303_Ball https://github.com/acemod/ACE3/blob/e5a15d200f44df5fccc0bc5575d18d80b35538dd/extras/CfgAmmoReference.hpp#L412
         ACE_caliber = 7.92; // https://bobp.cip-bobp.org/uploads/tdcc/tab-ii/tabiical-en-page74.pdf
         ACE_bulletLength = 31.166;
         ACE_bulletMass = 11.275; // 174 grains
@@ -80,77 +80,75 @@ class CfgAmmo {
         ACE_barrelLengths[] = {508.0, 609.6, 660.4}; // barrel length 640 mm
         airFriction = -0.00085112; // default -0.00105, ACE3 value -0.00085117 https://github.com/acemod/ACE3/blob/37daf3429dfd71a58a072d4198f094809dff66f6/extras/airFrictionAnalysis.txt#L194
         typicalSpeed = 761; // default 755
-	};
-	
-	class LIB_B_792x57_Ball: LIB_Bullet_base {
+    };
+
+    class LIB_B_792x57_Ball: LIB_Bullet_base {
         ACE_caliber = 7.925;
         ACE_bulletLength = 28.956;
         ACE_bulletMass = 9.8496;
-        ACE_ammoTempMuzzleVelocityShifts[] = { -26.55,-25.47,-22.85,-20.12,-16.98,-12.8,-7.64,-1.53,5.96,15.17,26.19 };
-        ACE_ballisticCoefficients[] = { 0.4 };
+        ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.8, -7.64, -1.53, 5.96, 15.17, 26.19};
+        ACE_ballisticCoefficients[] = {0.4};
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ICAO";
         ACE_dragModel = 1;
-        ACE_muzzleVelocities[] = { 700,800,820,833 };
-        ACE_barrelLengths[] = { 406.4,508,609.6,660.4 };
+        ACE_muzzleVelocities[] = {700, 800, 820, 833};
+        ACE_barrelLengths[] = {406.4, 508, 609.6, 660.4};
     };
-	
-	class LIB_B_792x33_Ball: LIB_Bullet_base { // Using LIB_B_762x54_Ball
+
+    class LIB_B_792x33_Ball: LIB_Bullet_base { // Using LIB_B_762x54_Ball
         ACE_caliber = 7.925;
         ACE_bulletLength = 28.956;
         ACE_bulletMass = 9.8496;
-        ACE_ammoTempMuzzleVelocityShifts[] = { -26.55,-25.47,-22.85,-20.12,-16.98,-12.8,-7.64,-1.53,5.96,15.17,26.19 };
-        ACE_ballisticCoefficients[] = { 0.4 };
+        ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.8, -7.64, -1.53, 5.96, 15.17, 26.19};
+        ACE_ballisticCoefficients[] = {0.4};
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ICAO";
         ACE_dragModel = 1;
-        ACE_muzzleVelocities[] = { 700,800,820,833 };
-        ACE_barrelLengths[] = { 406.4,508,609.6,660.4 };
+        ACE_muzzleVelocities[] = {700, 800, 820, 833};
+        ACE_barrelLengths[] = {406.4, 508, 609.6, 660.4};
     };
-	
-	class LIB_B_145x144_Ball: LIB_Bullet_base {
+
+    class LIB_B_145x144_Ball: LIB_Bullet_base {
         ACE_caliber = 7.925;
         ACE_bulletLength = 36.26;
         ACE_bulletMass = 64;
-        ACE_ammoTempMuzzleVelocityShifts[] = { -2.655,-2.547,-2.285,-2.012,-1.698,-1.28,-0.764,-0.153,0.596,1.517,2.619 };
-        ACE_ballisticCoefficients[] = { 1.05 };
+        ACE_ammoTempMuzzleVelocityShifts[] = {-2.655, -2.547, -2.285, -2.012, -1.698, -1.28, -0.764, -0.153, 0.596, 1.517, 2.619};
+        ACE_ballisticCoefficients[] = {1.05};
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
         ACE_dragModel = 1;
-        ACE_muzzleVelocities[] = { 1114 };
-        ACE_barrelLengths[] = { 1350 };
+        ACE_muzzleVelocities[] = {1114};
+        ACE_barrelLengths[] = {1350};
     };
-	
-	class BulletBase_NonAceAB;//BulletBase
-	class LIB_M2_Flamethrower_Ammo: BulletBase_NonAceAB//BulletBase
-	{
+
+    class BulletBase_NonAceAB; // BulletBase
+    class LIB_M2_Flamethrower_Ammo: BulletBase_NonAceAB { // BulletBase
         ACE_caliber = 0;
         ACE_bulletLength = 0;
         ACE_bulletMass = 0;
         ACE_ammoTempMuzzleVelocityShifts[] = {};
-        ACE_ballisticCoefficients[] = { 0 };
+        ACE_ballisticCoefficients[] = {0};
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ICAO";
         ACE_dragModel = 1;
-        ACE_muzzleVelocities[] = { 40 };
-        ACE_barrelLengths[] = { 0 };
-	};
-	
+        ACE_muzzleVelocities[] = {40};
+        ACE_barrelLengths[] = {0};
+    };
+
     class LIB_Bullet_Vehicle_base;
     class LIB_B_127x108_Ball: LIB_Bullet_Vehicle_base {
         ACE_caliber = 14.88;
         ACE_bulletLength = 64.516;
         ACE_bulletMass = 48.6;
-        ACE_ammoTempMuzzleVelocityShifts[] = { -2.655,-2.547,-2.285,-2.012,-1.698,-1.28,-0.764,-0.153,0.596,1.517,2.619 };
-        ACE_ballisticCoefficients[] = { 1.05 };
+        ACE_ammoTempMuzzleVelocityShifts[] = {-2.655, -2.547, -2.285, -2.012, -1.698, -1.28, -0.764, -0.153, 0.596, 1.517, 2.619};
+        ACE_ballisticCoefficients[] = {1.05};
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
         ACE_dragModel = 1;
-        ACE_muzzleVelocities[] = { 300 };
-        ACE_barrelLengths[] = { 436.88 };
+        ACE_muzzleVelocities[] = {300};
+        ACE_barrelLengths[] = {436.88};
     };
 
-	
     class LIB_Bullet_AA_base;
     class LIB_B_23mm_AA: LIB_Bullet_AA_base {
         ace_rearm_caliber = 23;
@@ -179,7 +177,7 @@ class CfgAmmo {
         ace_frag_charge = 700;
         ace_frag_gurney_c = 2027;
         ace_frag_gurney_k = "3/5";
-        ace_frag_classes[] = { "ACE_frag_small" };
+        ace_frag_classes[] = {"ACE_frag_small"};
         ace_frag_skip = 0;
         ace_frag_force = 1;
     };
@@ -190,54 +188,54 @@ class CfgAmmo {
         ace_frag_charge = 700;
         ace_frag_gurney_c = 2027;
         ace_frag_gurney_k = "3/5";
-        ace_frag_classes[] = { "ACE_frag_small" };
+        ace_frag_classes[] = {"ACE_frag_small"};
         ace_frag_skip = 0;
         ace_frag_force = 1;
     };
 
-	class LIB_89mm_PIAT: LIB_Rocket_base {
+    class LIB_89mm_PIAT: LIB_Rocket_base {
         ace_frag_enabled = 1;
         ace_frag_metal = 1200;
         ace_frag_charge = 700;
         ace_frag_gurney_c = 2027;
         ace_frag_gurney_k = "3/5";
-        ace_frag_classes[] = { "ACE_frag_small" };
+        ace_frag_classes[] = {"ACE_frag_small"};
         ace_frag_skip = 0;
         ace_frag_force = 1;
-	};
-	
+    };
+
     class LIB_GrenadeHand_base;
     class LIB_shg24: LIB_GrenadeHand_base {
         ace_frag_enabled = 1;
         ace_frag_skip = 0;
         ace_frag_force = 1;
-        ace_frag_classes[] = { "ACE_frag_tiny_HD" };
+        ace_frag_classes[] = {"ACE_frag_tiny_HD"};
         ace_frag_metal = 110;
         ace_frag_charge = 165;
         ace_frag_gurney_c = 2440;
         ace_frag_gurney_k = "3/5";
-		ace_advanced_throwing_torqueDirection[] = {1,0.2,0};
-		ace_advanced_throwing_torqueMagnitude = "(250 + random 100)";
+        ace_advanced_throwing_torqueDirection[] = {1, 0.2, 0};
+        ace_advanced_throwing_torqueMagnitude = "(250 + random 100)";
     };
 
     class LIB_shg24x7: LIB_GrenadeHand_base {
         ace_frag_enabled = 1;
         ace_frag_skip = 0;
         ace_frag_force = 1;
-        ace_frag_classes[] = { "ACE_frag_tiny_HD" };
+        ace_frag_classes[] = {"ACE_frag_tiny_HD"};
         ace_frag_metal = 770;
         ace_frag_charge = 1155;
         ace_frag_gurney_c = 2440;
         ace_frag_gurney_k = "3/5";
-		ace_advanced_throwing_torqueDirection[] = {1,0.2,0};
-		ace_advanced_throwing_torqueMagnitude = "(100 + random 100)";
+        ace_advanced_throwing_torqueDirection[] = {1, 0.2, 0};
+        ace_advanced_throwing_torqueMagnitude = "(100 + random 100)";
     };
 
     class LIB_m39: LIB_GrenadeHand_base {
         ace_frag_enabled = 1;
         ace_frag_skip = 0;
         ace_frag_force = 1;
-        ace_frag_classes[] = { "ACE_frag_tiny_HD" };
+        ace_frag_classes[] = {"ACE_frag_tiny_HD"};
         ace_frag_metal = 340;
         ace_frag_charge = 112;
         ace_frag_gurney_c = 2440;
@@ -248,7 +246,7 @@ class CfgAmmo {
         ace_frag_enabled = 1;
         ace_frag_skip = 0;
         ace_frag_force = 1;
-        ace_frag_classes[] = { "ACE_frag_tiny_HD" };
+        ace_frag_classes[] = {"ACE_frag_tiny_HD"};
         ace_frag_metal = 600;
         ace_frag_charge = 60;
         ace_frag_gurney_c = 2320;
@@ -259,7 +257,7 @@ class CfgAmmo {
         ace_frag_enabled = 1;
         ace_frag_skip = 0;
         ace_frag_force = 1;
-        ace_frag_classes[] = { "ACE_frag_small_HD" };
+        ace_frag_classes[] = {"ACE_frag_small_HD"};
         ace_frag_metal = 500;
         ace_frag_charge = 200;
         ace_frag_gurney_c = 2440;
@@ -270,40 +268,40 @@ class CfgAmmo {
         ace_frag_enabled = 1;
         ace_frag_skip = 0;
         ace_frag_force = 1;
-        ace_frag_classes[] = { "ACE_frag_tiny_HD" };
+        ace_frag_classes[] = {"ACE_frag_tiny_HD"};
         ace_frag_metal = 1100;
         ace_frag_charge = 570;
         ace_frag_gurney_c = 2440;
         ace_frag_gurney_k = "3/5";
-		ace_advanced_throwing_torqueDirection[] = {1,0.2,0};
-		ace_advanced_throwing_torqueMagnitude = "(100 + random 100)";
+        ace_advanced_throwing_torqueDirection[] = {1, 0.2, 0};
+        ace_advanced_throwing_torqueMagnitude = "(100 + random 100)";
     };
 
     class LIB_pwm: LIB_GrenadeHand_base {
         ace_frag_enabled = 1;
         ace_frag_skip = 0;
         ace_frag_force = 1;
-        ace_frag_classes[] = { "ACE_frag_tiny_HD" };
+        ace_frag_classes[] = {"ACE_frag_tiny_HD"};
         ace_frag_metal = 1000;
         ace_frag_charge = 500;
         ace_frag_gurney_c = 2440;
         ace_frag_gurney_k = "3/5";
-		ace_advanced_throwing_torqueDirection[] = {1,0.2,0};
-		ace_advanced_throwing_torqueMagnitude = "(10 + random 100)";
+        ace_advanced_throwing_torqueDirection[] = {1, 0.2, 0};
+        ace_advanced_throwing_torqueMagnitude = "(10 + random 100)";
     };
 
     class LIB_US_Mk_2: LIB_GrenadeHand_base {
         ace_frag_enabled = 1;
         ace_frag_skip = 0;
         ace_frag_force = 1;
-        ace_frag_classes[] = { "ACE_frag_small_HD" };
+        ace_frag_classes[] = {"ACE_frag_small_HD"};
         ace_frag_metal = 595;
         ace_frag_charge = 57;
         ace_frag_gurney_c = 2440;
         ace_frag_gurney_k = "3/5";
     };
 
-	class LIB_MillsBomb: LIB_GrenadeHand_base {
+    class LIB_MillsBomb: LIB_GrenadeHand_base {
         ace_frag_enabled = 1;
         ace_frag_skip = 0;
         ace_frag_force = 1;
@@ -313,123 +311,123 @@ class CfgAmmo {
         ace_frag_gurney_c = 2440;
         ace_frag_gurney_k = "3/5";
     };
-	
-	class LIB_No82: LIB_GrenadeHand_base {
+
+    class LIB_No82: LIB_GrenadeHand_base {
         ace_frag_enabled = 1;
         ace_frag_skip = 0;
         ace_frag_force = 0.5;
-        ace_frag_classes[] = { "ACE_frag_tiny_HD" };
+        ace_frag_classes[] = {"ACE_frag_tiny_HD"};
         ace_frag_metal = 340;
         ace_frag_charge = 900;
         ace_frag_gurney_c = 2440;
         ace_frag_gurney_k = "3/5";
-		ace_advanced_throwing_torqueDirection[] = {1,0.2,0};
-		ace_advanced_throwing_torqueMagnitude = "(100 + random 100)";
+        ace_advanced_throwing_torqueDirection[] = {1, 0.2, 0};
+        ace_advanced_throwing_torqueMagnitude = "(100 + random 100)";
     };
-	
-	class LIB_No77: LIB_GrenadeHand_base {
+
+    class LIB_No77: LIB_GrenadeHand_base {
         ace_frag_enabled = 0;
         ace_frag_skip = 1;
     };
-	
-	class LIB_Grenade_base;
-	class LIB_G_SPRGR_30: LIB_Grenade_base {
+
+    class LIB_Grenade_base;
+    class LIB_G_SPRGR_30: LIB_Grenade_base {
         ace_frag_enabled = 1;
         ace_frag_skip = 0;
         ace_frag_force = 1;
-        ace_frag_classes[] = { "ACE_frag_tiny_HD" };
+        ace_frag_classes[] = {"ACE_frag_tiny_HD"};
         ace_frag_metal = 255;
         ace_frag_charge = 31;
         ace_frag_gurney_c = 2440;
         ace_frag_gurney_k = "3/5";
     };
-	
-	class LIB_G_PZGR_30: LIB_Grenade_base {
+
+    class LIB_G_PZGR_30: LIB_Grenade_base {
         ace_frag_enabled = 1;
         ace_frag_skip = 0;
         ace_frag_force = 1;
-        ace_frag_classes[] = { "ACE_frag_tiny_HD" };
+        ace_frag_classes[] = {"ACE_frag_tiny_HD"};
         ace_frag_metal = 240;
         ace_frag_charge = 50;
         ace_frag_gurney_c = 2440;
         ace_frag_gurney_k = "3/5";
     };
-	
-	class LIB_G_PZGR_40: LIB_Grenade_base {
+
+    class LIB_G_PZGR_40: LIB_Grenade_base {
         ace_frag_enabled = 1;
         ace_frag_skip = 0;
         ace_frag_force = 1;
-        ace_frag_classes[] = { "ACE_frag_tiny_HD" };
+        ace_frag_classes[] = {"ACE_frag_tiny_HD"};
         ace_frag_metal = 380;
         ace_frag_charge = 127.6;
         ace_frag_gurney_c = 2440;
         ace_frag_gurney_k = "3/5";
     };
-	
-	class LIB_G_MK2: LIB_Grenade_base {
+
+    class LIB_G_MK2: LIB_Grenade_base {
         ace_frag_enabled = 1;
         ace_frag_skip = 0;
         ace_frag_force = 1;
-        ace_frag_classes[] = { "ACE_frag_small_HD" };
+        ace_frag_classes[] = {"ACE_frag_small_HD"};
         ace_frag_metal = 595;
         ace_frag_charge = 57;
         ace_frag_gurney_c = 2440;
         ace_frag_gurney_k = "3/5";
     };
-	
-	class LIB_G_M9A1: LIB_Grenade_base {
+
+    class LIB_G_M9A1: LIB_Grenade_base {
         ace_frag_enabled = 1;
         ace_frag_skip = 0;
         ace_frag_force = 1;
-        ace_frag_classes[] = { "ACE_frag_tiny_HD" };
+        ace_frag_classes[] = {"ACE_frag_tiny_HD"};
         ace_frag_metal = 590;
         ace_frag_charge = 113;
         ace_frag_gurney_c = 2440;
         ace_frag_gurney_k = "3/5";
     };
-	
-	class LIB_G_DYAKONOV: LIB_Grenade_base {
+
+    class LIB_G_DYAKONOV: LIB_Grenade_base {
         ace_frag_enabled = 1;
         ace_frag_skip = 0;
         ace_frag_force = 1;
-        ace_frag_classes[] = { "ACE_frag_tiny_HD" };
+        ace_frag_classes[] = {"ACE_frag_tiny_HD"};
         ace_frag_metal = 360;
         ace_frag_charge = 40;
         ace_frag_gurney_c = 2320;
         ace_frag_gurney_k = "3/5";
     };
-	
-	class LIB_G_MillsBomb: LIB_Grenade_base {
+
+    class LIB_G_MillsBomb: LIB_Grenade_base {
         ace_frag_enabled = 1;
         ace_frag_skip = 0;
         ace_frag_force = 1;
-        ace_frag_classes[] = { "ACE_frag_small_HD" };
+        ace_frag_classes[] = {"ACE_frag_small_HD"};
         ace_frag_metal = 695;
         ace_frag_charge = 70;
         ace_frag_gurney_c = 2440;
         ace_frag_gurney_k = "3/5";
     };
-	
-	class LIB_G_89mm_PIAT: LIB_Grenade_base {
+
+    class LIB_G_89mm_PIAT: LIB_Grenade_base {
         ace_frag_enabled = 1;
         ace_frag_metal = 1200;
         ace_frag_charge = 700;
         ace_frag_gurney_c = 2027;
         ace_frag_gurney_k = "3/5";
-        ace_frag_classes[] = { "ACE_frag_small" };
+        ace_frag_classes[] = {"ACE_frag_small"};
         ace_frag_skip = 0;
         ace_frag_force = 1;
-	};
-	
-	class LIB_Bomb_base;
+    };
+
+    class LIB_Bomb_base;
     class LIB_FAB500_Bomb: LIB_Bomb_base {
         ace_frag_enabled = 1;
         ace_frag_skip = 0;
         ace_frag_force = 1;
-        ace_frag_classes[] = { "ACE_frag_large","ACE_frag_large","ACE_frag_large_HD","ACE_frag_large","ACE_frag_huge","ACE_frag_huge_HD","ACE_frag_huge" };
+        ace_frag_classes[] = {"ACE_frag_large", "ACE_frag_large", "ACE_frag_large_HD", "ACE_frag_large", "ACE_frag_huge", "ACE_frag_huge_HD", "ACE_frag_huge"};
         ace_frag_metal = 515;
         ace_frag_charge = 226;
-        ace_frag_gurney_c = 2027; //60% amatol (1886) + 40% TNT (2240) = 2027 m/s
+        ace_frag_gurney_c = 2027; // 60% amatol (1886) + 40% TNT (2240) = 2027 m/s
         ace_frag_gurney_k = "1/2";
     };
 
@@ -437,10 +435,10 @@ class CfgAmmo {
         ace_frag_enabled = 1;
         ace_frag_skip = 0;
         ace_frag_force = 1;
-        ace_frag_classes[] = { "ACE_frag_large","ACE_frag_large","ACE_frag_large_HD","ACE_frag_large","ACE_frag_huge","ACE_frag_huge_HD","ACE_frag_huge" };
+        ace_frag_classes[] = {"ACE_frag_large", "ACE_frag_large", "ACE_frag_large_HD","ACE_frag_large", "ACE_frag_huge", "ACE_frag_huge_HD", "ACE_frag_huge"};
         ace_frag_metal = 500;
         ace_frag_charge = 260;
-        ace_frag_gurney_c = 2027; //60% amatol (1886) + 40% TNT (2240) = 2027 m/s
+        ace_frag_gurney_c = 2027; // 60% amatol (1886) + 40% TNT (2240) = 2027 m/s
         ace_frag_gurney_k = "1/2";
     };
 
@@ -448,10 +446,10 @@ class CfgAmmo {
         ace_frag_enabled = 1;
         ace_frag_skip = 0;
         ace_frag_force = 1;
-        ace_frag_classes[] = { "ACE_frag_large","ACE_frag_large","ACE_frag_large_HD","ACE_frag_large","ACE_frag_huge","ACE_frag_huge_HD","ACE_frag_huge" };
+        ace_frag_classes[] = {"ACE_frag_large", "ACE_frag_large", "ACE_frag_large_HD", "ACE_frag_large", "ACE_frag_huge", "ACE_frag_huge_HD", "ACE_frag_huge"};
         ace_frag_metal = 207;
         ace_frag_charge = 113;
-        ace_frag_gurney_c = 2027; //60% amatol (1886) + 40% TNT (2240) = 2027 m/s
+        ace_frag_gurney_c = 2027; // 60% amatol (1886) + 40% TNT (2240) = 2027 m/s
         ace_frag_gurney_k = "1/2";
     };
 
@@ -459,10 +457,10 @@ class CfgAmmo {
         ace_frag_enabled = 1;
         ace_frag_skip = 0;
         ace_frag_force = 1;
-        ace_frag_classes[] = { "ACE_frag_large","ACE_frag_large","ACE_frag_large_HD","ACE_frag_large","ACE_frag_huge","ACE_frag_huge_HD","ACE_frag_huge" };
+        ace_frag_classes[] = {"ACE_frag_large", "ACE_frag_large", "ACE_frag_large_HD", "ACE_frag_large", "ACE_frag_huge", "ACE_frag_huge_HD", "ACE_frag_huge"};
         ace_frag_metal = 250;
         ace_frag_charge = 130;
-        ace_frag_gurney_c = 2027; //60% amatol (1886) + 40% TNT (2240) = 2027 m/s
+        ace_frag_gurney_c = 2027; // 60% amatol (1886) + 40% TNT (2240) = 2027 m/s
         ace_frag_gurney_k = "1/2";
     };
 
@@ -470,10 +468,10 @@ class CfgAmmo {
         ace_frag_enabled = 1;
         ace_frag_skip = 0;
         ace_frag_force = 1;
-        ace_frag_classes[] = { "ACE_frag_large","ACE_frag_large","ACE_frag_large_HD","ACE_frag_large","ACE_frag_huge","ACE_frag_huge_HD","ACE_frag_huge" };
+        ace_frag_classes[] = {"ACE_frag_large", "ACE_frag_large", "ACE_frag_large_HD", "ACE_frag_large", "ACE_frag_huge", "ACE_frag_huge_HD", "ACE_frag_huge"};
         ace_frag_metal = 50;
         ace_frag_charge = 30;
-        ace_frag_gurney_c = 2027; //60% amatol (1886) + 40% TNT (2240) = 2027 m/s
+        ace_frag_gurney_c = 2027; // 60% amatol (1886) + 40% TNT (2240) = 2027 m/s
         ace_frag_gurney_k = "1/2";
     };
 
@@ -481,18 +479,17 @@ class CfgAmmo {
         ace_frag_enabled = 1;
         ace_frag_skip = 0;
         ace_frag_force = 1;
-        ace_frag_classes[] = { "ACE_frag_large","ACE_frag_large","ACE_frag_large_HD","ACE_frag_large","ACE_frag_huge","ACE_frag_huge_HD","ACE_frag_huge" };
+        ace_frag_classes[] = {"ACE_frag_large", "ACE_frag_large", "ACE_frag_large_HD", "ACE_frag_large", "ACE_frag_huge", "ACE_frag_huge_HD", "ACE_frag_huge"};
         ace_frag_metal = 213;
         ace_frag_charge = 63;
-        ace_frag_gurney_c = 2027; //60% amatol (1886) + 40% TNT (2240) = 2027 m/s
+        ace_frag_gurney_c = 2027; // 60% amatol (1886) + 40% TNT (2240) = 2027 m/s
         ace_frag_gurney_k = "1/2";
     };
-
 
     class Sh_82mm_AMOS;
     class LIB_Sh_82_HE: Sh_82mm_AMOS {
         ace_frag_enabled = 1;
-        ace_frag_classes[] = { "ACE_frag_medium","ACE_frag_medium_HD" };
+        ace_frag_classes[] = {"ACE_frag_medium", "ACE_frag_medium_HD"};
         ace_frag_metal = 3400;
         ace_frag_charge = 420;
         ace_frag_gurney_c = 2027;
@@ -502,7 +499,7 @@ class CfgAmmo {
 
     class ARTY_LIB_Sh_82_HE: LIB_Sh_82_HE {
         ace_frag_enabled = 1;
-        ace_frag_classes[] = { "ACE_frag_medium","ACE_frag_medium_HD" };
+        ace_frag_classes[] = {"ACE_frag_medium", "ACE_frag_medium_HD"};
         ace_frag_metal = 3400;
         ace_frag_charge = 420;
         ace_frag_gurney_c = 2027;
@@ -512,7 +509,7 @@ class CfgAmmo {
 
     class LIB_Sh_81_HE: LIB_Sh_82_HE {
         ace_frag_enabled = 1;
-        ace_frag_classes[] = { "ACE_frag_medium","ACE_frag_medium_HD" };
+        ace_frag_classes[] = {"ACE_frag_medium", "ACE_frag_medium_HD"};
         ace_frag_metal = 3110;
         ace_frag_charge = 100;
         ace_frag_gurney_c = 2027;
@@ -522,7 +519,7 @@ class CfgAmmo {
 
     class ARTY_LIB_Sh_81_HE: LIB_Sh_81_HE {
         ace_frag_enabled = 1;
-        ace_frag_classes[] = { "ACE_frag_medium","ACE_frag_medium_HD" };
+        ace_frag_classes[] = {"ACE_frag_medium", "ACE_frag_medium_HD"};
         ace_frag_metal = 3110;
         ace_frag_charge = 400;
         ace_frag_gurney_c = 2027;
@@ -616,88 +613,88 @@ class CfgAmmo {
         ace_frag_skip = 1;
     };
 
-	class LIB_KGrRotPz_K51_AP: LIB_Shell_base {
-		ace_rearm_caliber = 75;
+    class LIB_KGrRotPz_K51_AP: LIB_Shell_base {
+        ace_rearm_caliber = 75;
         ace_frag_skip = 1;
-	};
-	
-	class LIB_6pdr_mk7_AP: LIB_Shell_base {
+    };
+
+    class LIB_6pdr_mk7_AP: LIB_Shell_base {
         ace_rearm_caliber = 57;
-        ace_frag_skip = 1;		
-	};
-	
-	class LIB_6pdr_Mk1T_APCR: LIB_ShellAPCR_base {
+        ace_frag_skip = 1;
+    };
+
+    class LIB_6pdr_Mk1T_APCR: LIB_ShellAPCR_base {
         ace_rearm_caliber = 57;
-        ace_frag_skip = 1;		
-	};
-	
+        ace_frag_skip = 1;
+    };
+
     class LIB_Bullet_Plane_base;
     class LIB_B_37mm_AP: LIB_Bullet_Plane_base {
         ace_rearm_caliber = 37;
         ace_frag_skip = 1;
     };
-	class LIB_B_40mm_AP: LIB_Bullet_Plane_base {
+    class LIB_B_40mm_AP: LIB_Bullet_Plane_base {
         ace_rearm_caliber = 40;
         ace_frag_skip = 1;
     };
 
-	//I44
-	class LIB_S_37L57_M74: LIB_Shell_base {
+    //I44
+    class LIB_S_37L57_M74: LIB_Shell_base {
         ace_rearm_caliber = 37;
-        ace_frag_skip = 1;		
-	};
-	
-	class LIB_S_76L55_M79: LIB_Shell_base {
+        ace_frag_skip = 1;
+    };
+
+    class LIB_S_76L55_M79: LIB_Shell_base {
         ace_rearm_caliber = 76;
-        ace_frag_skip = 1;		
-	};
-	
-	class LIB_S_76L55_APMk3: LIB_Shell_base {
+        ace_frag_skip = 1;
+    };
+
+    class LIB_S_76L55_APMk3: LIB_Shell_base {
         ace_rearm_caliber = 76;
-        ace_frag_skip = 1;		
-	};
-	
-	class LIB_S_20L55_PzGr: LIB_Shell_base {
+        ace_frag_skip = 1;
+    };
+
+    class LIB_S_20L55_PzGr: LIB_Shell_base {
         ace_rearm_caliber = 20;
-        ace_frag_skip = 1;		
-	};
-	
-	class LIB_S_50L60_PzGr: LIB_Shell_base {
+        ace_frag_skip = 1;
+    };
+
+    class LIB_S_50L60_PzGr: LIB_Shell_base {
         ace_rearm_caliber = 50;
-        ace_frag_skip = 1;		
-	};
-	
-	class LIB_S_37L57_M51: LIB_ShellAPCR_base {
+        ace_frag_skip = 1;
+    };
+
+    class LIB_S_37L57_M51: LIB_ShellAPCR_base {
         ace_rearm_caliber = 37;
-        ace_frag_skip = 1;				
-	};
-	
-	class LIB_S_76L55_M93: LIB_ShellAPCR_base {
+        ace_frag_skip = 1;
+    };
+
+    class LIB_S_76L55_M93: LIB_ShellAPCR_base {
         ace_rearm_caliber = 76;
-        ace_frag_skip = 1;				
-	};
-	
-	class LIB_S_76L55_APDSMk1: LIB_ShellAPCR_base {
+        ace_frag_skip = 1;
+    };
+
+    class LIB_S_76L55_APDSMk1: LIB_ShellAPCR_base {
         ace_rearm_caliber = 76;
-        ace_frag_skip = 1;				
-	};
-	
-	class LIB_S_20L55_PzGr40: LIB_ShellAPCR_base {
+        ace_frag_skip = 1;
+    };
+
+    class LIB_S_20L55_PzGr40: LIB_ShellAPCR_base {
         ace_rearm_caliber = 20;
-        ace_frag_skip = 1;				
-	};
-	
-	class LIB_S_50L60_PzGr40: LIB_ShellAPCR_base {
+        ace_frag_skip = 1;
+    };
+
+    class LIB_S_50L60_PzGr40: LIB_ShellAPCR_base {
         ace_rearm_caliber = 50;
-        ace_frag_skip = 1;				
-	};
-	// I44-End	
+        ace_frag_skip = 1;
+    };
+    // I44-End
 
     class LIB_ShellHE_base;
     class LIB_OF471_HE: LIB_ShellHE_base {
         ace_rearm_caliber = 122;
         ace_frag_enabled = 1;
-        ace_frag_classes[] = { "ACE_frag_medium","ACE_frag_medium_HD" };
+        ace_frag_classes[] = {"ACE_frag_medium", "ACE_frag_medium_HD"};
         ace_frag_metal = 25000;
         ace_frag_charge = 3600;
         ace_frag_gurney_c = 2440;
@@ -707,17 +704,17 @@ class CfgAmmo {
     class LIB_SprGr34_KWK40_HE: LIB_ShellHE_base {
         ace_rearm_caliber = 75;
         ace_frag_enabled = 1;
-        ace_frag_classes[] = { "ACE_frag_medium","ACE_frag_medium_HD" };
+        ace_frag_classes[] = {"ACE_frag_medium", "ACE_frag_medium_HD"};
         ace_frag_metal = 5750;
         ace_frag_charge = 660;
-        ace_frag_gurney_c = 1886; //100% Amatol
+        ace_frag_gurney_c = 1886; // 100% Amatol
         ace_frag_gurney_k = "1/2";
     };
 
     class LIB_SprGr42_KwK42_HE: LIB_ShellHE_base {
         ace_rearm_caliber = 75;
         ace_frag_enabled = 1;
-        ace_frag_classes[] = { "ACE_frag_medium","ACE_frag_medium_HD" };
+        ace_frag_classes[] = {"ACE_frag_medium", "ACE_frag_medium_HD"};
         ace_frag_metal = 5740;
         ace_frag_charge = 670;
         ace_frag_gurney_c = 1886;
@@ -727,7 +724,7 @@ class CfgAmmo {
     class LIB_SprGr39_HE: LIB_ShellHE_base {
         ace_rearm_caliber = 88;
         ace_frag_enabled = 1;
-        ace_frag_classes[] = { "ACE_frag_medium","ACE_frag_medium_HD" };
+        ace_frag_classes[] = {"ACE_frag_medium", "ACE_frag_medium_HD"};
         ace_frag_metal = 10400;
         ace_frag_charge = 590;
         ace_frag_gurney_c = 1886;
@@ -737,7 +734,7 @@ class CfgAmmo {
     class LIB_SprGr_KwK36_HE: LIB_ShellHE_base {
         ace_rearm_caliber = 88;
         ace_frag_enabled = 1;
-        ace_frag_classes[] = { "ACE_frag_medium","ACE_frag_medium_HD" };
+        ace_frag_classes[] = {"ACE_frag_medium", "ACE_frag_medium_HD"};
         ace_frag_metal = 10400;
         ace_frag_charge = 590;
         ace_frag_gurney_c = 1886;
@@ -747,120 +744,120 @@ class CfgAmmo {
     class LIB_O365_HE: LIB_ShellHE_base {
         ace_rearm_caliber = 85;
         ace_frag_enabled = 1;
-        ace_frag_classes[] = { "ACE_frag_medium","ACE_frag_medium_HD" };
+        ace_frag_classes[] = {"ACE_frag_medium", "ACE_frag_medium_HD"};
         ace_frag_metal = 9200;
         ace_frag_charge = 646;
-        ace_frag_gurney_c = 2440; //100% TNT
+        ace_frag_gurney_c = 2440; // 100% TNT
         ace_frag_gurney_k = "1/2";
     };
 
     class LIB_M42A1_M1_HE: LIB_ShellHE_base {
         ace_rearm_caliber = 76;
         ace_frag_enabled = 1;
-        ace_frag_classes[] = { "ACE_frag_medium","ACE_frag_medium_HD" };
+        ace_frag_classes[] = {"ACE_frag_medium", "ACE_frag_medium_HD"};
         ace_frag_metal = 5840;
         ace_frag_charge = 390;
         ace_frag_gurney_c = 2440;
         ace_frag_gurney_k = "1/2";
     };
-	
-	class LIB_SprGr34_K51_HE: LIB_ShellHE_base {
+
+    class LIB_SprGr34_K51_HE: LIB_ShellHE_base {
         ace_rearm_caliber = 75;
         ace_frag_enabled = 1;
-        ace_frag_classes[] = { "ACE_frag_medium","ACE_frag_medium_HD" };
+        ace_frag_classes[] = {"ACE_frag_medium", "ACE_frag_medium_HD"};
         ace_frag_metal = 4422;
         ace_frag_charge = 454;
         ace_frag_gurney_c = 2440;
         ace_frag_gurney_k = "1/2";
-	};
-	
-	class LIB_6pdr_mk10T_HE: LIB_ShellHE_base {
+    };
+
+    class LIB_6pdr_mk10T_HE: LIB_ShellHE_base {
         ace_rearm_caliber = 57;
         ace_frag_enabled = 1;
-        ace_frag_classes[] = { "ACE_frag_medium","ACE_frag_medium_HD" };
+        ace_frag_classes[] = {"ACE_frag_medium", "ACE_frag_medium_HD"};
         ace_frag_metal = 1780;
         ace_frag_charge = 165;
-        ace_frag_gurney_c = 1886; //100% Amatol
+        ace_frag_gurney_c = 1886; // 100% Amatol
         ace_frag_gurney_k = "1/2";
-	};
-	
-	//I44
-	class LIB_S_37L57_M63: LIB_ShellHE_base {
+    };
+
+    //I44
+    class LIB_S_37L57_M63: LIB_ShellHE_base {
         ace_rearm_caliber = 37;
         ace_frag_enabled = 1;
-        ace_frag_classes[] = { "ACE_frag_medium","ACE_frag_medium_HD" };
+        ace_frag_classes[] = {"ACE_frag_medium", "ACE_frag_medium_HD"};
         ace_frag_metal = 730;
         ace_frag_charge = 39;
-         ace_frag_gurney_c = 2440; //100% TNT
+        ace_frag_gurney_c = 2440; // 100% TNT
         ace_frag_gurney_k = "1/2";
-	};
-	
-	class LIB_S_76L55_M42: LIB_ShellHE_base {
+    };
+
+    class LIB_S_76L55_M42: LIB_ShellHE_base {
         ace_rearm_caliber = 76;
         ace_frag_enabled = 1;
-        ace_frag_classes[] = { "ACE_frag_medium","ACE_frag_medium_HD" };
+        ace_frag_classes[] = {"ACE_frag_medium", "ACE_frag_medium_HD"};
         ace_frag_metal = 5840;
         ace_frag_charge = 390;
-         ace_frag_gurney_c = 2440; //100% TNT
+        ace_frag_gurney_c = 2440; // 100% TNT
         ace_frag_gurney_k = "1/2";
-	};
-	
-	class LIB_S_76L55_HEMk1: LIB_ShellHE_base {
+    };
+
+    class LIB_S_76L55_HEMk1: LIB_ShellHE_base {
         ace_rearm_caliber = 76;
         ace_frag_enabled = 1;
-        ace_frag_classes[] = { "ACE_frag_medium","ACE_frag_medium_HD" };
+        ace_frag_classes[] = {"ACE_frag_medium", "ACE_frag_medium_HD"};
         ace_frag_metal = 6990;
         ace_frag_charge = 710;
-         ace_frag_gurney_c = 2440; //100% TNT
+        ace_frag_gurney_c = 2440; // 100% TNT
         ace_frag_gurney_k = "1/2";
-	};
-	
-	class LIB_S_20L55_SprGr: LIB_ShellHE_base {
+    };
+
+    class LIB_S_20L55_SprGr: LIB_ShellHE_base {
         ace_rearm_caliber = 20;
         ace_frag_enabled = 1;
-        ace_frag_classes[] = { "ACE_frag_small","ACE_frag_small_HD" };
+        ace_frag_classes[] = {"ACE_frag_small", "ACE_frag_small_HD"};
         ace_frag_metal = 117;
         ace_frag_charge = 37;
-        ace_frag_gurney_c = 1886; //100% Amatol
+        ace_frag_gurney_c = 1886; // 100% Amatol
         ace_frag_gurney_k = "1/2";
-	};
-	
-	class LIB_S_50L60_SprGr38: LIB_ShellHE_base	{
+    };
+
+    class LIB_S_50L60_SprGr38: LIB_ShellHE_base {
         ace_rearm_caliber = 50;
         ace_frag_enabled = 1;
-        ace_frag_classes[] = { "ACE_frag_medium","ACE_frag_medium_HD" };
+        ace_frag_classes[] = {"ACE_frag_medium", "ACE_frag_medium_HD"};
         ace_frag_metal = 1780;
         ace_frag_charge = 165;
-        ace_frag_gurney_c = 1886; //100% Amatol
+        ace_frag_gurney_c = 1886; // 100% Amatol
         ace_frag_gurney_k = "1/2";
-	};
-	
-	class LIB_S_105L28_Gr39HlC: LIB_ShellHE_base {
+    };
+
+    class LIB_S_105L28_Gr39HlC: LIB_ShellHE_base {
         ace_rearm_caliber = 105;
         ace_frag_enabled = 1;
-        ace_frag_classes[] = { "ACE_frag_medium","ACE_frag_medium_HD" };
+        ace_frag_classes[] = {"ACE_frag_medium", "ACE_frag_medium_HD"};
         ace_frag_metal = 12350;
         ace_frag_charge = 1700;
-        ace_frag_gurney_c = 1886; //100% Amatol
+        ace_frag_gurney_c = 1886; // 100% Amatol
         ace_frag_gurney_k = "1/2";
-	};
-	
-	class LIB_S_105L28_Gr38: LIB_ShellHE_base {
+    };
+
+    class LIB_S_105L28_Gr38: LIB_ShellHE_base {
         ace_rearm_caliber = 105;
         ace_frag_enabled = 1;
-        ace_frag_classes[] = { "ACE_frag_medium","ACE_frag_medium_HD" };
+        ace_frag_classes[] = {"ACE_frag_medium", "ACE_frag_medium_HD"};
         ace_frag_metal = 14810;
         ace_frag_charge = 1380;
-        ace_frag_gurney_c = 1886; //100% Amatol
+        ace_frag_gurney_c = 1886; // 100% Amatol
         ace_frag_gurney_k = "1/2";
-	};
-	// I44-End
+    };
+    // I44-End
 
     class LIB_76mm_Shell_Base_HE;
     class LIB_OF350_HE: LIB_76mm_Shell_Base_HE {
         ace_rearm_caliber = 76;
         ace_frag_enabled = 1;
-        ace_frag_classes[] = { "ACE_frag_medium","ACE_frag_medium_HD" };
+        ace_frag_classes[] = {"ACE_frag_medium", "ACE_frag_medium_HD"};
         ace_frag_metal = 6200;
         ace_frag_charge = 621;
         ace_frag_gurney_c = 2440;
@@ -871,19 +868,18 @@ class CfgAmmo {
     class LIB_OF471_HE_Arty: Sh_155mm_AMOS {
         ace_rearm_caliber = 122;
         ace_frag_enabled = 1;
-        ace_frag_classes[] = { "ACE_frag_medium","ACE_frag_medium_HD" };
+        ace_frag_classes[] = {"ACE_frag_medium", "ACE_frag_medium_HD"};
         ace_frag_metal = 25530;
         ace_frag_charge = 6580;
         ace_frag_gurney_c = 2440;
         ace_frag_gurney_k = "1/2";
     };
 
-
     class R_60mm_HE;
     class LIB_R_M8: R_60mm_HE {
         ace_rearm_caliber = 110;
         ace_frag_enabled = 1;
-        ace_frag_classes[] = { "ACE_frag_medium","ACE_frag_medium_HD" };
+        ace_frag_classes[] = {"ACE_frag_medium", "ACE_frag_medium_HD"};
         ace_frag_metal = 17;
         ace_frag_charge = 2;
         ace_frag_gurney_c = 2027;
@@ -895,10 +891,11 @@ class CfgAmmo {
         // ace_explosives_magazine = "LIB_Ladung_Small_MINE_mag";
         ace_explosives_Explosive = "LIB_Ladung_Small_ammo_Scripted";
         ace_explodeOnDefuse = 0.02;
-        ace_explosives_defuseObjectPosition[] = { 0.07,0,0.055 };
+        ace_explosives_defuseObjectPosition[] = {0.07, 0, 0.055};
         soundActivation[] = {"", 0, 0, 0};
         soundDeactivation[] = {"", 0, 0, 0};
     };
+
     class LIB_Ladung_Small_ammo_Scripted: LIB_Ladung_Small_ammo {
         triggerWhenDestroyed = 1;
     };
@@ -907,10 +904,11 @@ class CfgAmmo {
         // ace_explosives_magazine = "LIB_Ladung_Big_MINE_mag";
         ace_explosives_Explosive = "LIB_Ladung_Big_ammo_Scripted";
         ace_explodeOnDefuse = 0.02;
-        ace_explosives_defuseObjectPosition[] = { 0.07,0,0.055 };
+        ace_explosives_defuseObjectPosition[] = {0.07, 0, 0.055};
         soundActivation[] = {"", 0, 0, 0};
         soundDeactivation[] = {"", 0, 0, 0};
     };
+
     class LIB_Ladung_Big_ammo_Scripted: LIB_Ladung_Big_ammo {
         triggerWhenDestroyed = 1;
     };
@@ -919,10 +917,11 @@ class CfgAmmo {
         // ace_explosives_magazine = "LIB_US_TNT_4pound_mag";
         ace_explosives_Explosive = "LIB_US_TNT_4pound_ammo_Scripted";
         ace_explodeOnDefuse = 0.02;
-        ace_explosives_defuseObjectPosition[] = { 0.07,0,0.055 };
+        ace_explosives_defuseObjectPosition[] = {0.07, 0, 0.055};
         soundActivation[] = {"", 0, 0, 0};
         soundDeactivation[] = {"", 0, 0, 0};
     };
+
     class LIB_US_TNT_4pound_ammo_Scripted: LIB_US_TNT_4pound_ammo {
         triggerWhenDestroyed = 1;
     };
@@ -930,79 +929,78 @@ class CfgAmmo {
     class LIB_MAIN_mine;
     class LIB_TMI42_ammo: LIB_MAIN_mine {
         ace_explodeOnDefuse = 0.02;
-        ace_explosives_defuseObjectPosition[] = { 0,0,0.07 };
+        ace_explosives_defuseObjectPosition[] = {0, 0, 0.07};
         soundActivation[] = {"", 0, 0, 0};
         soundDeactivation[] = {"", 0, 0, 0};
     };
 
     class LIB_SMI35_1_ammo: LIB_MAIN_mine {
         ace_explodeOnDefuse = 0.02;
-        ace_explosives_defuseObjectPosition[] = { 0,0,0.06 };
+        ace_explosives_defuseObjectPosition[] = {0, 0, 0.06};
         soundActivation[] = {"", 0, 0, 0};
         soundDeactivation[] = {"", 0, 0, 0};
     };
 
     class LIB_pomzec_ammo: LIB_MAIN_mine {
         ace_explodeOnDefuse = 0.02;
-        ace_explosives_defuseObjectPosition[] = { 1.85,0,0.1 };
+        ace_explosives_defuseObjectPosition[] = {1.85, 0, 0.1};
         soundActivation[] = {"", 0, 0, 0};
         soundDeactivation[] = {"", 0, 0, 0};
     };
 
     class LIB_SMI35_ammo: LIB_MAIN_mine {
         ace_explodeOnDefuse = 0.02;
-        ace_explosives_defuseObjectPosition[] = { 1.85,0,0.06 };
+        ace_explosives_defuseObjectPosition[] = {1.85, 0, 0.06};
         soundActivation[] = {"", 0, 0, 0};
         soundDeactivation[] = {"", 0, 0, 0};
     };
 
     class LIB_STMI_ammo: LIB_MAIN_mine {
         ace_explodeOnDefuse = 0.02;
-        ace_explosives_defuseObjectPosition[] = { 1.85,0,0.1 };
+        ace_explosives_defuseObjectPosition[] = {1.85, 0, 0.1};
         soundActivation[] = {"", 0, 0, 0};
         soundDeactivation[] = {"", 0, 0, 0};
     };
 
     class LIB_shumine42_ammo: LIB_MAIN_mine {
         ace_explodeOnDefuse = 0.02;
-        ace_explosives_defuseObjectPosition[] = { 0,0,0.07 };
+        ace_explosives_defuseObjectPosition[] = {0, 0, 0.07};
         soundActivation[] = {"", 0, 0, 0};
         soundDeactivation[] = {"", 0, 0, 0};
     };
 
     class LIB_M3_ammo: LIB_MAIN_mine {
         ace_explodeOnDefuse = 0.02;
-        ace_explosives_defuseObjectPosition[] = { 1.85,0,0.07 };
+        ace_explosives_defuseObjectPosition[] = {1.85, 0, 0.07};
         soundActivation[] = {"", 0, 0, 0};
         soundDeactivation[] = {"", 0, 0, 0};
     };
 
     class LIB_PMD6_ammo: LIB_MAIN_mine {
         ace_explodeOnDefuse = 0.02;
-        ace_explosives_defuseObjectPosition[] = { 0,0,0.07 };
+        ace_explosives_defuseObjectPosition[] = {0, 0, 0.07};
         soundActivation[] = {"", 0, 0, 0};
         soundDeactivation[] = {"", 0, 0, 0};
     };
 
     class LIB_TM44_ammo: LIB_MAIN_mine {
         ace_explodeOnDefuse = 0.02;
-        ace_explosives_defuseObjectPosition[] = { 0,0,0.07 };
+        ace_explosives_defuseObjectPosition[] = {0, 0, 0.07};
         soundActivation[] = {"", 0, 0, 0};
         soundDeactivation[] = {"", 0, 0, 0};
     };
 
     class LIB_US_M1A1_ATMINE_ammo: LIB_MAIN_mine {
         ace_explodeOnDefuse = 0.02;
-        ace_explosives_defuseObjectPosition[] = { 0,0,0.07 };
+        ace_explosives_defuseObjectPosition[] = {0, 0, 0.07};
         soundActivation[] = {"", 0, 0, 0};
         soundDeactivation[] = {"", 0, 0, 0};
     };
 
-  class LIB_US_M3_ammo: LIB_MAIN_mine {
+    class LIB_US_M3_ammo: LIB_MAIN_mine {
         ace_explodeOnDefuse = 0.02;
-        ace_explosives_defuseObjectPosition[] = { 1.85,0,0.07 };
+        ace_explosives_defuseObjectPosition[] = {1.85, 0, 0.07};
         soundActivation[] = {"", 0, 0, 0};
         soundDeactivation[] = {"", 0, 0, 0};
     };
-
 };

--- a/addons/main/CfgAmmo.hpp
+++ b/addons/main/CfgAmmo.hpp
@@ -77,7 +77,7 @@ class CfgAmmo {
         ACE_standardAtmosphere = "ASM";
         ACE_dragModel = 1;
         ACE_muzzleVelocities[] = {748, 761, 765}; // muzzle velocity 764 m/s at 21°C, 756 m/s at 15°C (2440 fps +/-50 fps at 30 yards with a standart deviation of no more than 40 fps - The Accurate Lee Enfield by Stephen Redgwell)
-        ACE_barrelLengths[] = {508.0, 609.6, 660.4};
+        ACE_barrelLengths[] = {508.0, 609.6, 660.4}; // barrel length 640 mm
         airFriction = -0.00085112; // default -0.00105, ACE3 value -0.00085117 https://github.com/acemod/ACE3/blob/37daf3429dfd71a58a072d4198f094809dff66f6/extras/airFrictionAnalysis.txt#L194
         typicalSpeed = 761; // default 755
 	};

--- a/addons/main/CfgAmmo.hpp
+++ b/addons/main/CfgAmmo.hpp
@@ -76,10 +76,10 @@ class CfgAmmo {
         ACE_velocityBoundaries[] = {};
         ACE_standardAtmosphere = "ASM";
         ACE_dragModel = 1;
-        ACE_muzzleVelocities[] = {748, 761, 765}; // muzzle velocity 764 m/s at 21°C, 756 m/s at 15°C (2440 fps +/-50 fps at 30 yards with a standart deviation of no more than 40 fps - The Accurate Lee Enfield by Stephen Redgwell)
+        ACE_muzzleVelocities[] = {751, 764, 768}; // muzzle velocity 767 m/s at 21°C, 759 m/s at 15°C (normal conditions), in-game exactly "2440 fps (743 m/s) +/-50 fps at 30 yards (27.43 m) with a standart deviation of no more than 40 fps" - The Accurate Lee Enfield by Stephen Redgwell)
         ACE_barrelLengths[] = {508.0, 609.6, 660.4}; // barrel length 640 mm
-        airFriction = -0.00085112; // default -0.00105, ACE3 value -0.00085117 https://github.com/acemod/ACE3/blob/37daf3429dfd71a58a072d4198f094809dff66f6/extras/airFrictionAnalysis.txt#L194
-        typicalSpeed = 761; // default 755
+        airFriction = -0.000865; // default -0.00105, ACE3 value -0.00085117 https://github.com/acemod/ACE3/blob/37daf3429dfd71a58a072d4198f094809dff66f6/extras/airFrictionAnalysis.txt#L194
+        typicalSpeed = 759; // default 755
     };
 
     class LIB_B_792x57_Ball: LIB_Bullet_base {
@@ -157,6 +157,7 @@ class CfgAmmo {
     class LIB_4x_SprGr_FlaK_38: LIB_Bullet_AA_base {
         ace_rearm_caliber = 20;
     };
+
     class LIB_SprGr_FlaK_38: LIB_4x_SprGr_FlaK_38 {
         ace_rearm_caliber = 20;
     };
@@ -633,12 +634,13 @@ class CfgAmmo {
         ace_rearm_caliber = 37;
         ace_frag_skip = 1;
     };
+
     class LIB_B_40mm_AP: LIB_Bullet_Plane_base {
         ace_rearm_caliber = 40;
         ace_frag_skip = 1;
     };
 
-    //I44
+    // I44
     class LIB_S_37L57_M74: LIB_Shell_base {
         ace_rearm_caliber = 37;
         ace_frag_skip = 1;
@@ -781,7 +783,7 @@ class CfgAmmo {
         ace_frag_gurney_k = "1/2";
     };
 
-    //I44
+    // I44
     class LIB_S_37L57_M63: LIB_ShellHE_base {
         ace_rearm_caliber = 37;
         ace_frag_enabled = 1;

--- a/addons/main/CfgWeapons.hpp
+++ b/addons/main/CfgWeapons.hpp
@@ -163,12 +163,12 @@ class CfgWeapons {
     class LIB_LeeEnfield_No4: LIB_RIFLE {
         ACE_barrelTwist = 254;
         ACE_barrelLength = 640.08;
-        initSpeed = -1.02153432; // 743*1.02153432= 759 m/s, LIB_10Rnd_770x56 initSpeed according with the Lee-Enfield muzzle velocity at 15°C (normal conditions)
+        initSpeed = -1.02288; // 743*1.02288= 760 m/s, LIB_10Rnd_770x56 initSpeed according with the Lee-Enfield muzzle velocity at 15°C (normal conditions)
     };
 
     class LIB_LeeEnfield_No1: LIB_LeeEnfield_No4 {
         ACE_barrelLength = 640.08;
-        initSpeed = -1.02153432; // 743*1.02153432= 759 m/s, LIB_10Rnd_770x56 initSpeed according with the Lee-Enfield muzzle velocity at 15°C (normal conditions)
+        initSpeed = -1.02288; // 743*1.02288= 760 m/s, LIB_10Rnd_770x56 initSpeed according with the Lee-Enfield muzzle velocity at 15°C (normal conditions)
     };
 
     class LIB_PIAT_Rifle: LIB_RIFLE {
@@ -282,7 +282,7 @@ class CfgWeapons {
         ACE_ScopeAdjust_Horizontal[] = {-5, 5}; // turret 0-16, +- 16 MOA approximately 4.65 mRad
         ACE_ScopeAdjust_VerticalIncrement = 0.1; // should be 1 inch at 50 yards http://photos.imageevent.com/badgerdog/britishservicerifles/britishmilitaryaccessories/no32mk1watsonscopeserial1302/sniper-6.jpg
         ACE_ScopeAdjust_HorizontalIncrement = 0.1; // should be 2 MOA for the oldest versions, 1 MOA for the latest
-        initSpeed = -1.02153432; // 743*1.02153432= 759 m/s, LIB_10Rnd_770x56 initSpeed according with the Lee-Enfield muzzle velocity at 15°C (normal conditions)
+        initSpeed = -1.02288; // 743*1.02288= 760 m/s, LIB_10Rnd_770x56 initSpeed according with the Lee-Enfield muzzle velocity at 15°C (normal conditions)
     };
 
     class MGun;

--- a/addons/main/CfgWeapons.hpp
+++ b/addons/main/CfgWeapons.hpp
@@ -5,29 +5,29 @@ class CfgWeapons {
         ACE_barrelTwist = 254;
         ACE_barrelLength = 125.0;
     };
-	
-	class LIB_P08: LIB_P38 {
+
+    class LIB_P08: LIB_P38 {
         ACE_barrelTwist = 233.68;
         ACE_barrelLength = 100;
     };
-	
-	class LIB_M1896: LIB_PISTOL {
+
+    class LIB_M1896: LIB_PISTOL {
         ACE_barrelTwist = 203.2;
         ACE_barrelLength = 99;
     };
-	
-	class LIB_WaltherPPK: LIB_PISTOL {
+
+    class LIB_WaltherPPK: LIB_PISTOL {
         ACE_barrelTwist = 254;
         ACE_barrelLength = 83;
     };
-	
+
     class LIB_TT33: LIB_PISTOL {
-        ACE_barrelTwist = 406.4; //unknown
+        ACE_barrelTwist = 406.4; // unknown
         ACE_barrelLength = 130.0;
     };
 
     class LIB_M1895: LIB_PISTOL {
-        ACE_barrelTwist = 406.4; //unknown
+        ACE_barrelTwist = 406.4; // unknown
         ACE_barrelLength = 114.0;
     };
 
@@ -36,16 +36,16 @@ class CfgWeapons {
         ACE_barrelLength = 127.0;
     };
 
-	class LIB_Webley_mk6: LIB_PISTOL {
-        ACE_barrelTwist = 406.4; //unknown
+    class LIB_Webley_mk6: LIB_PISTOL {
+        ACE_barrelTwist = 406.4; // unknown
         ACE_barrelLength = 152.0;
     };
-	
-	class LIB_Welrod_mk1: LIB_PISTOL {
-        ACE_barrelTwist = 406.4; //unknown
+
+    class LIB_Welrod_mk1: LIB_PISTOL {
+        ACE_barrelTwist = 406.4; // unknown
         ACE_barrelLength = 83.0;
     };
-	
+
     class Rifle_Base_F;
     class Rifle_Short_Base_F: Rifle_Base_F {};
     class LIB_SMG: Rifle_Short_Base_F {
@@ -60,13 +60,13 @@ class CfgWeapons {
         ACE_barrelLength = 251;
     };
 
-	class LIB_MP38: LIB_SMG {
+    class LIB_MP38: LIB_SMG {
         ACE_barrelTwist = 203.2;
         ACE_barrelLength = 251;
     };
-	
+
     class LIB_PPSh41_m: LIB_SMG {
-        ACE_barrelTwist = 392; //unknown set same as thompson
+        ACE_barrelTwist = 392; // unknown set same as thompson
         ACE_barrelLength = 269;
     };
 
@@ -74,17 +74,17 @@ class CfgWeapons {
         ACE_barrelTwist = 392;
         ACE_barrelLength = 270;
     };
-	
-	class LIB_M3_GreaseGun: LIB_SMG {
+
+    class LIB_M3_GreaseGun: LIB_SMG {
         ACE_barrelTwist = 392;
         ACE_barrelLength = 270;
     };
 
-	class LIB_Sten_Mk2: LIB_SMG {
+    class LIB_Sten_Mk2: LIB_SMG {
         ACE_barrelTwist = 254;
         ACE_barrelLength = 196;
-	};
-	
+    };
+
     class LIB_RIFLE: Rifle_Base_F {
         ACE_Overheating_Dispersion = 0.75;
         ACE_Overheating_SlowdownFactor = 1;
@@ -102,40 +102,40 @@ class CfgWeapons {
         ACE_barrelLength = 730;
     };
 
-	class LIB_M1903A3_Springfield: LIB_RIFLE {
+    class LIB_M1903A3_Springfield: LIB_RIFLE {
         ACE_barrelTwist = 254;
         ACE_barrelLength = 610;
     };
-	
+
     class LIB_MP44: LIB_RIFLE {
         ACE_Overheating_JamChance = 0.0015;
-        ACE_barrelTwist = 254; //unknown set to 1:10
+        ACE_barrelTwist = 254; // unknown set to 1:10
         ACE_barrelLength = 420;
     };
 
     class LIB_SVT_40: LIB_RIFLE {
         ACE_Overheating_JamChance = 0.0003;
-        ACE_barrelTwist = 254; //unknown set to 1:10
+        ACE_barrelTwist = 254; // unknown set to 1:10
         ACE_barrelLength = 625;
     };
 
     class LIB_G43: LIB_RIFLE {
         ACE_Overheating_JamChance = 0.0003;
-        ACE_barrelTwist = 254; //unknown set to 1:10
+        ACE_barrelTwist = 254; // unknown set to 1:10
         ACE_barrelLength = 550;
     };
-	
-	class LIB_G41 : LIB_RIFLE {
-		ACE_barrelTwist=240; //unknown set to same as K98
-		ACE_barrelLength=546;
-		ACE_twistDirection=1;
-	};
-	
-	class LIB_FG42G : LIB_RIFLE {
-		ACE_barrelLength=500;
-		ACE_barrelTwist=240; //unknown set to same as K98
-		ACE_twistDirection=1;
-	};
+
+    class LIB_G41 : LIB_RIFLE {
+        ACE_barrelTwist = 240; // unknown set to same as K98
+        ACE_barrelLength = 546;
+        ACE_twistDirection = 1;
+    };
+
+    class LIB_FG42G : LIB_RIFLE {
+        ACE_barrelLength = 500;
+        ACE_barrelTwist = 240; // unknown set to same as K98
+        ACE_twistDirection = 1;
+    };
 
     class LIB_M1_Garand: LIB_RIFLE {
         ACE_Overheating_JamChance = 0.0003;
@@ -145,40 +145,40 @@ class CfgWeapons {
 
     class LIB_M1_Carbine: LIB_RIFLE {
         ACE_Overheating_JamChance = 0.0003;
-        ACE_barrelTwist = 254; //unknown set to 1:10
+        ACE_barrelTwist = 254; // unknown set to 1:10
         ACE_barrelLength = 460;
     };
 
-	class LIB_PTRD: LIB_RIFLE {
+    class LIB_PTRD: LIB_RIFLE {
         ACE_Overheating_JamChance = 0;
         ACE_barrelTwist = 304.8;
         ACE_barrelLength = 1350;
     };
-	
-	class LIB_DELISLE: LIB_RIFLE {
+
+    class LIB_DELISLE: LIB_RIFLE {
         ACE_barrelTwist = 392;
         ACE_barrelLength = 210;
     };
-	
-	class LIB_LeeEnfield_No4: LIB_RIFLE {
+
+    class LIB_LeeEnfield_No4: LIB_RIFLE {
         ACE_barrelTwist = 254;
         ACE_barrelLength = 640.08;
-        initSpeed = -1.017497 // 743*1.017497= 756 m/s, LIB_10Rnd_770x56 initSpeed according with the Lee-Enfield muzzle velocity at 15°C (normal conditions)
-	};
-	
-	class LIB_LeeEnfield_No1: LIB_LeeEnfield_No4 {
+        initSpeed = -1.017497; // 743*1.017497= 756 m/s, LIB_10Rnd_770x56 initSpeed according with the Lee-Enfield muzzle velocity at 15°C (normal conditions)
+    };
+
+    class LIB_LeeEnfield_No1: LIB_LeeEnfield_No4 {
         ACE_barrelLength = 640.08;
-        initSpeed = -1.017497 // 743*1.017497= 756 m/s, LIB_10Rnd_770x56 initSpeed according with the Lee-Enfield muzzle velocity at 15°C (normal conditions)
-	};
-	
-	class LIB_PIAT_Rifle: LIB_RIFLE {
-		ACE_Overheating_JamChance = 0;
-	};
-	
-	class LIB_M2_Flamethrower: LIB_RIFLE {
-		ACE_Overheating_JamChance = 0;
-	};
-	
+        initSpeed = -1.017497; // 743*1.017497= 756 m/s, LIB_10Rnd_770x56 initSpeed according with the Lee-Enfield muzzle velocity at 15°C (normal conditions)
+    };
+
+    class LIB_PIAT_Rifle: LIB_RIFLE {
+        ACE_Overheating_JamChance = 0;
+    };
+
+    class LIB_M2_Flamethrower: LIB_RIFLE {
+        ACE_Overheating_JamChance = 0;
+    };
+
     class Rifle_Long_Base_F: Rifle_Base_F {};
     class LIB_LMG: Rifle_Long_Base_F {
         ACE_Overheating_Dispersion = 0.75;
@@ -189,12 +189,12 @@ class CfgWeapons {
     };
 
     class LIB_DP28: LIB_LMG {
-        ACE_barrelTwist = 254; //unknown set to 1:10
+        ACE_barrelTwist = 254; // unknown set to 1:10
         ACE_barrelLength = 604;
     };
 
     class LIB_DT: LIB_LMG {
-        ACE_barrelTwist = 254; //unknown set to 1:10
+        ACE_barrelTwist = 254; // unknown set to 1:10
         ACE_barrelLength = 604;
     };
 
@@ -203,28 +203,28 @@ class CfgWeapons {
         ACE_barrelLength = 533;
     };
 
-	class LIB_MG34: LIB_LMG {
+    class LIB_MG34: LIB_LMG {
         ACE_barrelTwist = 101.6;
         ACE_barrelLength = 627;
     };
-	
-	class LIB_M1919A4: LIB_LMG {
+
+    class LIB_M1919A4: LIB_LMG {
         ACE_barrelTwist = 254;
         ACE_barrelLength = 610;
     };
-	
+
     class LIB_M1918A2_BAR: LIB_LMG {
-        ACE_barrelTwist = 254; //unknown set to 1:10
+        ACE_barrelTwist = 254; // unknown set to 1:10
         ACE_barrelLength = 610;
         ACE_overheating_allowSwapBarrel = 0;
     };
 
-	class LIB_Bren_Mk2: LIB_LMG {
-        ACE_barrelTwist = 254; //unknown set to 1:10
+    class LIB_Bren_Mk2: LIB_LMG {
+        ACE_barrelTwist = 254; // unknown set to 1:10
         ACE_barrelLength = 635;
         ACE_overheating_allowSwapBarrel = 1;
     };
-	
+
     class LIB_SRIFLE: Rifle_Long_Base_F {
         ACE_Overheating_Dispersion = 0.75;
         ACE_Overheating_SlowdownFactor = 1;
@@ -235,46 +235,46 @@ class CfgWeapons {
     class LIB_K98ZF39: LIB_SRIFLE {
         ACE_barrelTwist = 240;
         ACE_barrelLength = 600;
-		ACE_scopeZeroRange = 100;
-		ACE_ScopeAdjust_Vertical[] = {-4, 30};
+        ACE_scopeZeroRange = 100;
+        ACE_ScopeAdjust_Vertical[] = {-4, 30};
         ACE_ScopeAdjust_Horizontal[] = {-6, 6};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
-		discreteDistance[] = {100};
+        discreteDistance[] = {100};
         discreteDistanceInitIndex = 0;
-		ACE_railHeightAboveBore = 1.8;  // Distance between center of bore and rail in centimeters
+        ACE_railHeightAboveBore = 1.8;  // Distance between center of bore and rail in centimeters
         ACE_scopeHeightAboveRail = 3.8;  // Distance between center of scope and rail in centimeters
     };
 
     class LIB_M9130PU: LIB_SRIFLE {
         ACE_barrelTwist = 254;
         ACE_barrelLength = 730;
-		ACE_scopeZeroRange = 100;
-		ACE_ScopeAdjust_Vertical[] = {-4, 30};
+        ACE_scopeZeroRange = 100;
+        ACE_ScopeAdjust_Vertical[] = {-4, 30};
         ACE_ScopeAdjust_Horizontal[] = {-6, 6};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
-		discreteDistance[] = {100};
+        discreteDistance[] = {100};
         discreteDistanceInitIndex = 0;
-		ACE_railHeightAboveBore = 1.8;
+        ACE_railHeightAboveBore = 1.8;
         ACE_scopeHeightAboveRail = 3.8;
     };
 
     class LIB_M1903A4_Springfield: LIB_SRIFLE {
         ACE_barrelTwist = 254;
         ACE_barrelLength = 610;
-		ACE_scopeZeroRange = 100;
-		ACE_ScopeAdjust_Vertical[] = {-4, 30};
+        ACE_scopeZeroRange = 100;
+        ACE_ScopeAdjust_Vertical[] = {-4, 30};
         ACE_ScopeAdjust_Horizontal[] = {-6, 6};
         ACE_ScopeAdjust_VerticalIncrement = 0.1;
         ACE_ScopeAdjust_HorizontalIncrement = 0.1;
-		discreteDistance[] = {100};
+        discreteDistance[] = {100};
         discreteDistanceInitIndex = 0;
-		ACE_railHeightAboveBore = 1.8;
+        ACE_railHeightAboveBore = 1.8;
         ACE_scopeHeightAboveRail = 3.8;
     };
 
-	class LIB_LeeEnfield_No4_Scoped: LIB_SRIFLE { // Lee Enfield No32 Sniper's Scope http://www.allaboutenfields.co.nz/links-resouces/articles/from-no4mk-i-t-l42-ai/ http://www.rsmscope.com/report_pdf/RSM_No23MKII_Telescope.pdf https://www.youtube.com/watch?v=JlzIc4MzqPs
+    class LIB_LeeEnfield_No4_Scoped: LIB_SRIFLE { // Lee Enfield No32 Sniper's Scope http://www.allaboutenfields.co.nz/links-resouces/articles/from-no4mk-i-t-l42-ai/ http://www.rsmscope.com/report_pdf/RSM_No23MKII_Telescope.pdf https://www.youtube.com/watch?v=JlzIc4MzqPs
         ACE_barrelTwist = 254; // 1:10"
         ACE_barrelLength = 640.08; // 25.2"
         ACE_scopeZeroRange = 100;
@@ -283,7 +283,7 @@ class CfgWeapons {
         ACE_ScopeAdjust_VerticalIncrement = 0.1; // should be 1 inch at 50 yards http://photos.imageevent.com/badgerdog/britishservicerifles/britishmilitaryaccessories/no32mk1watsonscopeserial1302/sniper-6.jpg
         ACE_ScopeAdjust_HorizontalIncrement = 0.1; // should be 2 MOA for the oldest versions, 1 MOA for the latest
         discreteDistanceInitIndex = 0;
-        initSpeed = -1.017497 // 743*1.017497= 756 m/s, LIB_10Rnd_770x56 initSpeed according with the Lee-Enfield muzzle velocity at 15°C (normal conditions)
+        initSpeed = -1.017497; // 743*1.017497= 756 m/s, LIB_10Rnd_770x56 initSpeed according with the Lee-Enfield muzzle velocity at 15°C (normal conditions)
     };
 
     class MGun;
@@ -302,64 +302,64 @@ class CfgWeapons {
     };
 
     class LIB_Maxim_M30: LIB_MLMG_base {
-        ACE_barrelTwist = 254; //unknown set to 1:10
+        ACE_barrelTwist = 254; // unknown set to 1:10
         ACE_barrelLength = 732;
         ACE_overheating_allowSwapBarrel = 0;
     };
 
-	class LIB_TankMGun_base: MGun {
+    class LIB_TankMGun_base: MGun {
         ACE_Overheating_Dispersion = 0.75;
         ACE_Overheating_SlowdownFactor = 1;
         ACE_Overheating_JamChance = 0.0075;
         ACE_overheating_mrbs = 3000;
         ACE_overheating_allowSwapBarrel = 1;
     };
-	
-	class LIB_DT29: LIB_TankMGun_base {
-        ACE_barrelTwist = 254; //unknown set to 1:10
+
+    class LIB_DT29: LIB_TankMGun_base {
+        ACE_barrelTwist = 254; // unknown set to 1:10
         ACE_barrelLength = 604;
     };
-	
-	class LIB_MG34_coax: LIB_TankMGun_base {
+
+    class LIB_MG34_coax: LIB_TankMGun_base {
         ACE_barrelTwist = 101.6;
         ACE_barrelLength = 627;
     };
-	
-	class LIB_M1919A4_coax: LIB_TankMGun_base {
+
+    class LIB_M1919A4_coax: LIB_TankMGun_base {
         ACE_barrelTwist = 254;
         ACE_barrelLength = 610;
     };
-	
-	class LIB_Bren_Mk2_coax: LIB_TankMGun_base {
-        ACE_barrelTwist = 254; //unknown set to 1:10
+
+    class LIB_Bren_Mk2_coax: LIB_TankMGun_base {
+        ACE_barrelTwist = 254; // unknown set to 1:10
         ACE_barrelLength = 635;
     };
-	
-	class LIB_Besa_coax: LIB_TankMGun_base {
+
+    class LIB_Besa_coax: LIB_TankMGun_base {
         ACE_barrelTwist = 101.6;
         ACE_barrelLength = 740;
         ACE_overheating_allowSwapBarrel = 1;
     };
-	
-	
+
     class LIB_LAUNCHER;
     class LIB_PzFaust_30m: LIB_LAUNCHER {
         ACE_UsedTube = "LIB_PzFaust_30m_used";
-        magazines[] = { "LIB_PzFaust_PreloadedMissileDummy" };  // The dummy magazine
+        magazines[] = {"LIB_PzFaust_PreloadedMissileDummy"}; // The dummy magazine
         ace_overpressure_angle = 45;
         ace_overpressure_range = 5;
         ace_overpressure_damage = 0.3;
     };
+
     class LIB_PzFaust_60m: LIB_PzFaust_30m {
         ACE_UsedTube = "LIB_PzFaust_60m_used";
-        // magazines[] = { "LIB_PzFaust_PreloadedMissileDummy" };  // The dummy magazine
+        // magazines[] = {"LIB_PzFaust_PreloadedMissileDummy"}; // The dummy magazine
     };
     // class LIB_Faustpatrone: LIB_PzFaust_30m {};
 
     class LIB_PzFaust_30m_used: LIB_PzFaust_30m {
         scope = 1;
         ACE_isUsedLauncher = 1;
-        magazines[] = { "LIB_PzFaust_FiredMissileDummy" };  // This will disable the used launcher class from being fired again
+        magazines[] = {"LIB_PzFaust_FiredMissileDummy"}; // This will disable the used launcher class from being fired again
         weaponPoolAvailable = 0;
     };
     // class LIB_PzFaust_60m_used: LIB_PzFaust_30m_used {};
@@ -368,30 +368,30 @@ class CfgWeapons {
         ace_overpressure_angle = 60;
         ace_overpressure_range = 10;
         ace_overpressure_damage = 0.4;
-		ace_reloadlaunchers_enabled = 1;
+        ace_reloadlaunchers_enabled = 1;
     };
 
     class LIB_M1A1_Bazooka: LIB_LAUNCHER {
         ace_overpressure_angle = 60;
         ace_overpressure_range = 10;
         ace_overpressure_damage = 0.4;
-		ace_reloadlaunchers_enabled = 1;
+        ace_reloadlaunchers_enabled = 1;
     };
 
-	class LIB_PIAT: LIB_LAUNCHER {
+    class LIB_PIAT: LIB_LAUNCHER {
         ace_overpressure_angle = 0;
         ace_overpressure_range = 0;
         ace_overpressure_damage = 0;
-		ace_reloadlaunchers_enabled = 0;
-	};
-	
-	class Launcher_Base_F;
-	class LIB_Bagpipes: Launcher_Base_F {
+        ace_reloadlaunchers_enabled = 0;
+    };
+
+    class Launcher_Base_F;
+    class LIB_Bagpipes: Launcher_Base_F {
         ace_overpressure_angle = 0;
         ace_overpressure_range = 0;
         ace_overpressure_damage = 0;
-		ace_reloadlaunchers_enabled = 0;
-	};
+        ace_reloadlaunchers_enabled = 0;
+    };
 
     class H_LIB_HelmetB;
     class H_LIB_Hat;
@@ -413,11 +413,11 @@ class CfgWeapons {
         ace_hearing_lowerVolume = 0.60;
     };
 
-	class H_LIB_US_Helmet_Tank: H_LIB_HelmetB {
+    class H_LIB_US_Helmet_Tank: H_LIB_HelmetB {
         ACE_Protection = 1;
         ace_hearing_protection = 0.50;
         ace_hearing_lowerVolume = 0.60;
-	};
+    };
 
     class LIB_TankCannon_base;
 
@@ -482,63 +482,63 @@ class CfgWeapons {
         ace_overpressure_damage = 0.4;
     };
 
-	class LIB_K51_L54_base: LIB_TankCannon_base {
+    class LIB_K51_L54_base: LIB_TankCannon_base {
         ace_overpressure_angle = 80;
         ace_overpressure_range = 10;
         ace_overpressure_damage = 0.2;
-	};
-	
+    };
+
     class LIB_OQF_75_base: LIB_TankCannon_base {
         ace_overpressure_angle = 90;
         ace_overpressure_range = 15;
         ace_overpressure_damage = 0.4;
     };
-	
-	class LIB_OQF_57_base: LIB_TankCannon_base {
+
+    class LIB_OQF_57_base: LIB_TankCannon_base {
         ace_overpressure_angle = 60;
         ace_overpressure_range = 5;
-        ace_overpressure_damage = 0.4;		
-	};
-	
-	// I44
-	class LIB_M6_L53_base: LIB_TankCannon_base {
+        ace_overpressure_damage = 0.4;
+    };
+
+    // I44
+    class LIB_M6_L53_base: LIB_TankCannon_base {
         ace_overpressure_angle = 60;
         ace_overpressure_range = 5;
-        ace_overpressure_damage = 0.4;		
-	};
-	
-	class LIB_M1A2_L55_base: LIB_TankCannon_base {
+        ace_overpressure_damage = 0.4;
+    };
+
+    class LIB_M1A2_L55_base: LIB_TankCannon_base {
         ace_overpressure_angle = 90;
         ace_overpressure_range = 15;
-        ace_overpressure_damage = 0.4;		
-	};
-	
-	class LIB_QF17_L55_base: LIB_TankCannon_base {
+        ace_overpressure_damage = 0.4;
+    };
+
+    class LIB_QF17_L55_base: LIB_TankCannon_base {
         ace_overpressure_angle = 90;
         ace_overpressure_range = 15;
-        ace_overpressure_damage = 0.4;		
-	};
-	
-	class LIB_KwK30_L55_base: LIB_TankCannon_base {
+        ace_overpressure_damage = 0.4;
+    };
+
+    class LIB_KwK30_L55_base: LIB_TankCannon_base {
         ace_overpressure_angle = 40;
         ace_overpressure_range = 4;
-        ace_overpressure_damage = 0.1;				
-	};
-	
-	class LIB_KwK38_L55_base: LIB_KwK30_L55_base {};
-	
-	class LIB_KwK39_L60_base: LIB_TankCannon_base {
+        ace_overpressure_damage = 0.1;
+    };
+
+    class LIB_KwK38_L55_base: LIB_KwK30_L55_base {};
+
+    class LIB_KwK39_L60_base: LIB_TankCannon_base {
         ace_overpressure_angle = 90;
         ace_overpressure_range = 15;
-        ace_overpressure_damage = 0.4;		
-	};
-	
-	class LIB_LeFH18_base: LIB_StaticGunCannon_base {
+        ace_overpressure_damage = 0.4;
+    };
+
+    class LIB_LeFH18_base: LIB_StaticGunCannon_base {
         ace_overpressure_angle = 90;
         ace_overpressure_range = 15;
-        ace_overpressure_damage = 0.4;		
-	};
-	// I44-End
+        ace_overpressure_damage = 0.4;
+    };
+    // I44-End
 
     class ACE_ItemCore;
     class ACE_ExplosiveItem;
@@ -558,7 +558,7 @@ class CfgWeapons {
         ace_explosives_Detonator = 1;
         ace_explosives_triggerType = "LIB_LadungPM";
         class ItemInfo: ACE_ExplosiveItem {
-            allowedSlots[] = { 901 };
+            allowedSlots[] = {901};
             mass = 20;
             uniformModel = "\WW2\Assets_m\Weapons\Mines_m\Inv\IF_Ladung_pm_inv.p3d";
         };
@@ -575,7 +575,7 @@ class CfgWeapons {
         ace_explosives_Detonator = 1;
         ace_explosives_triggerType = "FireCord";
         class ItemInfo: ACE_ExplosiveItem {
-            allowedSlots[] = { 901,701 };
+            allowedSlots[] = {901, 701};
             mass = 5;
             uniformModel = "\z\ace\addons\captives\models\ace_cabletie.p3d";
         };

--- a/addons/main/CfgWeapons.hpp
+++ b/addons/main/CfgWeapons.hpp
@@ -163,12 +163,10 @@ class CfgWeapons {
     class LIB_LeeEnfield_No4: LIB_RIFLE {
         ACE_barrelTwist = 254;
         ACE_barrelLength = 640.08;
-        initSpeed = -1.02288; // 743*1.02288= 760 m/s, LIB_10Rnd_770x56 initSpeed according with the Lee-Enfield muzzle velocity at 15°C (normal conditions)
     };
 
     class LIB_LeeEnfield_No1: LIB_LeeEnfield_No4 {
         ACE_barrelLength = 640.08;
-        initSpeed = -1.02288; // 743*1.02288= 760 m/s, LIB_10Rnd_770x56 initSpeed according with the Lee-Enfield muzzle velocity at 15°C (normal conditions)
     };
 
     class LIB_PIAT_Rifle: LIB_RIFLE {
@@ -282,7 +280,6 @@ class CfgWeapons {
         ACE_ScopeAdjust_Horizontal[] = {-5, 5}; // turret 0-16, +- 16 MOA approximately 4.65 mRad
         ACE_ScopeAdjust_VerticalIncrement = 0.1; // should be 1 inch at 50 yards http://photos.imageevent.com/badgerdog/britishservicerifles/britishmilitaryaccessories/no32mk1watsonscopeserial1302/sniper-6.jpg
         ACE_ScopeAdjust_HorizontalIncrement = 0.1; // should be 2 MOA for the oldest versions, 1 MOA for the latest
-        initSpeed = -1.02288; // 743*1.02288= 760 m/s, LIB_10Rnd_770x56 initSpeed according with the Lee-Enfield muzzle velocity at 15°C (normal conditions)
     };
 
     class MGun;

--- a/addons/main/CfgWeapons.hpp
+++ b/addons/main/CfgWeapons.hpp
@@ -282,6 +282,7 @@ class CfgWeapons {
         ACE_ScopeAdjust_Horizontal[] = {-5, 5}; // turret 0-16, +- 16 MOA approximately 4.65 mRad
         ACE_ScopeAdjust_VerticalIncrement = 0.1; // should be 1 inch at 50 yards http://photos.imageevent.com/badgerdog/britishservicerifles/britishmilitaryaccessories/no32mk1watsonscopeserial1302/sniper-6.jpg
         ACE_ScopeAdjust_HorizontalIncrement = 0.1; // should be 2 MOA for the oldest versions, 1 MOA for the latest
+        discreteDistanceInitIndex = 0;
         initSpeed = -1.017497 // 743*1.017497= 756 m/s, LIB_10Rnd_770x56 initSpeed according with the Lee-Enfield muzzle velocity at 15°C (normal conditions)
 	};
 

--- a/addons/main/CfgWeapons.hpp
+++ b/addons/main/CfgWeapons.hpp
@@ -162,11 +162,13 @@ class CfgWeapons {
 	
 	class LIB_LeeEnfield_No4: LIB_RIFLE {
         ACE_barrelTwist = 254;
-        ACE_barrelLength = 210;
+        ACE_barrelLength = 640.08;
+        initSpeed = -1.017497 // 743*1.017497= 756 m/s, LIB_10Rnd_770x56 initSpeed according with the Lee-Enfield muzzle velocity at 15°C (normal conditions)
 	};
 	
 	class LIB_LeeEnfield_No1: LIB_LeeEnfield_No4 {
-        ACE_barrelLength = 210;
+        ACE_barrelLength = 640.08;
+        initSpeed = -1.017497 // 743*1.017497= 756 m/s, LIB_10Rnd_770x56 initSpeed according with the Lee-Enfield muzzle velocity at 15°C (normal conditions)
 	};
 	
 	class LIB_PIAT_Rifle: LIB_RIFLE {
@@ -272,9 +274,15 @@ class CfgWeapons {
         ACE_scopeHeightAboveRail = 3.8;
     };
 
-	class LIB_LeeEnfield_No4_Scoped: LIB_SRIFLE {
-        ACE_barrelTwist = 254;
-        ACE_barrelLength = 210;		
+	class LIB_LeeEnfield_No4_Scoped: LIB_SRIFLE { // Lee Enfield No32 Sniper's Scope http://www.allaboutenfields.co.nz/links-resouces/articles/from-no4mk-i-t-l42-ai/ http://www.rsmscope.com/report_pdf/RSM_No23MKII_Telescope.pdf https://www.youtube.com/watch?v=JlzIc4MzqPs
+        ACE_barrelTwist = 254; // 1:10"
+        ACE_barrelLength = 640.08; // 25.2"
+        ACE_scopeZeroRange = 100;
+        ACE_ScopeAdjust_Vertical[] = {0, 24}; // BDC turret 0-10 x100 yards with IPHY clicks (Inch Per Hundred Yard) for the oldest versions, MOA for the latest, total elevation before zeroing seems to be around 84 MOA approximately 24.43 mRad
+        ACE_ScopeAdjust_Horizontal[] = {-5, 5}; // turret 0-16, +- 16 MOA approximately 4.65 mRad
+        ACE_ScopeAdjust_VerticalIncrement = 0.1; // should be 1 inch at 50 yards http://photos.imageevent.com/badgerdog/britishservicerifles/britishmilitaryaccessories/no32mk1watsonscopeserial1302/sniper-6.jpg
+        ACE_ScopeAdjust_HorizontalIncrement = 0.1; // should be 2 MOA for the oldest versions, 1 MOA for the latest
+        initSpeed = -1.017497 // 743*1.017497= 756 m/s, LIB_10Rnd_770x56 initSpeed according with the Lee-Enfield muzzle velocity at 15°C (normal conditions)
 	};
 
     class MGun;

--- a/addons/main/CfgWeapons.hpp
+++ b/addons/main/CfgWeapons.hpp
@@ -284,7 +284,7 @@ class CfgWeapons {
         ACE_ScopeAdjust_HorizontalIncrement = 0.1; // should be 2 MOA for the oldest versions, 1 MOA for the latest
         discreteDistanceInitIndex = 0;
         initSpeed = -1.017497 // 743*1.017497= 756 m/s, LIB_10Rnd_770x56 initSpeed according with the Lee-Enfield muzzle velocity at 15°C (normal conditions)
-	};
+    };
 
     class MGun;
     class LIB_MLMG_base;

--- a/addons/main/CfgWeapons.hpp
+++ b/addons/main/CfgWeapons.hpp
@@ -163,12 +163,12 @@ class CfgWeapons {
     class LIB_LeeEnfield_No4: LIB_RIFLE {
         ACE_barrelTwist = 254;
         ACE_barrelLength = 640.08;
-        initSpeed = -1.017497; // 743*1.017497= 756 m/s, LIB_10Rnd_770x56 initSpeed according with the Lee-Enfield muzzle velocity at 15°C (normal conditions)
+        initSpeed = -1.02153432; // 743*1.02153432= 759 m/s, LIB_10Rnd_770x56 initSpeed according with the Lee-Enfield muzzle velocity at 15°C (normal conditions)
     };
 
     class LIB_LeeEnfield_No1: LIB_LeeEnfield_No4 {
         ACE_barrelLength = 640.08;
-        initSpeed = -1.017497; // 743*1.017497= 756 m/s, LIB_10Rnd_770x56 initSpeed according with the Lee-Enfield muzzle velocity at 15°C (normal conditions)
+        initSpeed = -1.02153432; // 743*1.02153432= 759 m/s, LIB_10Rnd_770x56 initSpeed according with the Lee-Enfield muzzle velocity at 15°C (normal conditions)
     };
 
     class LIB_PIAT_Rifle: LIB_RIFLE {
@@ -277,13 +277,12 @@ class CfgWeapons {
     class LIB_LeeEnfield_No4_Scoped: LIB_SRIFLE { // Lee Enfield No32 Sniper's Scope http://www.allaboutenfields.co.nz/links-resouces/articles/from-no4mk-i-t-l42-ai/ http://www.rsmscope.com/report_pdf/RSM_No23MKII_Telescope.pdf https://www.youtube.com/watch?v=JlzIc4MzqPs
         ACE_barrelTwist = 254; // 1:10"
         ACE_barrelLength = 640.08; // 25.2"
-        ACE_scopeZeroRange = 100;
+        ACE_scopeZeroRange = 100; // should be 100 yards
         ACE_ScopeAdjust_Vertical[] = {0, 24}; // BDC turret 0-10 x100 yards with IPHY clicks (Inch Per Hundred Yard) for the oldest versions, MOA for the latest, total elevation before zeroing seems to be around 84 MOA approximately 24.43 mRad
         ACE_ScopeAdjust_Horizontal[] = {-5, 5}; // turret 0-16, +- 16 MOA approximately 4.65 mRad
         ACE_ScopeAdjust_VerticalIncrement = 0.1; // should be 1 inch at 50 yards http://photos.imageevent.com/badgerdog/britishservicerifles/britishmilitaryaccessories/no32mk1watsonscopeserial1302/sniper-6.jpg
         ACE_ScopeAdjust_HorizontalIncrement = 0.1; // should be 2 MOA for the oldest versions, 1 MOA for the latest
-        discreteDistanceInitIndex = 0;
-        initSpeed = -1.017497; // 743*1.017497= 756 m/s, LIB_10Rnd_770x56 initSpeed according with the Lee-Enfield muzzle velocity at 15°C (normal conditions)
+        initSpeed = -1.02153432; // 743*1.02153432= 759 m/s, LIB_10Rnd_770x56 initSpeed according with the Lee-Enfield muzzle velocity at 15°C (normal conditions)
     };
 
     class MGun;


### PR DESCRIPTION
From The Accurate Lee Enfield by Stephen Redgwell :  muzzle velocity "2440 fps +/-50 fps at 30 yards with a standard deviation of no more than 40 fps".

That means approximately 743 m/s more or less 12 m/s at 27.43 meters.

With these values, IFA3 players will have exactly 743 m/s at the normal conditions with AB enabled and the default ballistic at this distance in-game with approximately identical bullet drops up to 1200 meters (max gap 0.1 mRad or 1 click) : 
[IFA3 Lee-Enfield Range Cards, effective bullet drops in-game with the both ballistics](https://steamuserimages-a.akamaihd.net/ugc/826883318588116333/350A8CB333DF16A7C1D3259C7D3A1644B199F9A3/).

`airFriction` calculated with the [Ruthberg airFriction tool](https://github.com/acemod/ACE3/blob/master/tools/generate_airfriction_config.py) :

> ##########################################
Ammo Class: LIB_B_770x56_Ball
MaxRanges (m): [1000, 1000]
MuzzleVelocities (m/s): [755, 765]
Max. Velocity diff (m/s): 6.12
Max. Drop diff (cm): 5.87
Max. Tof diff (ms): 8.0
Optimal airFriction: 0.00085276
##########################################