### PR TITLE
Add support for WP grenades for Advanced Throwing

### DIFF
--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 if (isClass(configfile >> "CfgPatches" >> "ace_cookoff")) then {
-  
+
     if (isServer) then {
       ["ace_cookoff_addTurretToEditable", {
           params ["_vehicle","_turret"];
@@ -21,3 +21,12 @@ if (isClass(configfile >> "CfgPatches" >> "ace_cookoff")) then {
       };
   }] call CBA_fnc_addClassEventHandler;
 };
+
+["ace_throwableThrown", {
+  params ["_unit", "_activeThrowable"];
+  if (isClass (configFile >> "CfgAmmo" >> (typeOf _activeThrowable) >> "Eventhandlers" >> "WW2_GAS")) then {
+    private _script = getText (configFile >> "CfgAmmo" >> (typeOf _activeThrowable) >> "Eventhandlers" >> "WW2_GAS" >> "Fired");
+    [_unit,"Throw","","", "", "", _activeThrowable] call compile _script;
+  };
+
+}] call CBA_fnc_addEventHandler;


### PR DESCRIPTION
We use a CfgAmmo Fired eventhandler for the WP grenades which doesn't get executed by ace advanced throwables, this script fixes that.

The event only fires when advanced throwable is used