### PR TITLE
Mortars cleanup

### DIFF
--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -1,4 +1,4 @@
-#define MAJOR 37
-#define MINOR 1
+#define MAJOR 40
+#define MINOR 0
 #define PATCHLVL 0
-#define BUILD 2
+#define BUILD 1

--- a/addons/mortar/CfgEventHandlers.hpp
+++ b/addons/mortar/CfgEventHandlers.hpp
@@ -1,11 +1,11 @@
 
-class Extended_PreStart_EventHandlers
-{
-	class ace_mk6mortar
-	{
-		init = "call compile preProcessFileLineNumbers '\z\ace\addons\mk6mortar\XEH_preStart.sqf'";
-	};
-};
+// class Extended_PreStart_EventHandlers
+// {
+// 	class ace_mk6mortar
+// 	{
+// 		init = "call compile preProcessFileLineNumbers '\z\ace\addons\mk6mortar\XEH_preStart.sqf'";
+// 	};
+// };
 
 class Extended_PreInit_EventHandlers {
     class ADDON {

--- a/addons/mortar/CfgMagazineGroups.hpp
+++ b/addons/mortar/CfgMagazineGroups.hpp
@@ -1,10 +1,17 @@
 class ace_csw_groups { // Ammo that can be loaded into CSW's
 	///// 82 mm ammo (for BM 37)
 	class LIB_1Rnd_82mm_Mo_HE { // The magazine which the player can place into their inventory
-		LIB_1Rnd_82mm_Mo_HE = 1; // Magazine that is loaded into the weapon as per CfgWeapons >> weapon >> magazines
+		LIB_1rnd_82mmHE_BM37 = 1; // Magazine that is loaded into the weapon as per CfgWeapons >> weapon >> magazines
+	};
+	class LIB_1rnd_82mmHE_BM37 { // The magazine which the player can place into their inventory
+		LIB_1rnd_82mmHE_BM37 = 1; // Magazine that is loaded into the weapon as per CfgWeapons >> weapon >> magazines
+		LIB_8Rnd_82mmHE_BM37 = 1;
 	};
 	class LIB_1Rnd_82mm_Mo_Smoke { // The magazine which the player can place into their inventory
-		LIB_1Rnd_82mm_Mo_Smoke = 1; // Magazine that is loaded into the weapon as per CfgWeapons >> weapon >> magazines
+		LIB_82mm_BM37_SmokeShell = 1; // Magazine that is loaded into the weapon as per CfgWeapons >> weapon >> magazines
+	};
+	class LIB_82mm_BM37_SmokeShell { // The magazine which the player can place into their inventory
+		LIB_82mm_BM37_SmokeShell = 1; // Magazine that is loaded into the weapon as per CfgWeapons >> weapon >> magazines
 	};
 	class LIB_1Rnd_82mm_Mo_Illum { // The magazine which the player can place into their inventory
 		LIB_1Rnd_82mm_Mo_Illum = 1; // Magazine that is loaded into the weapon as per CfgWeapons >> weapon >> magazines
@@ -13,10 +20,17 @@ class ace_csw_groups { // Ammo that can be loaded into CSW's
 
 	///// 81 mm ammo (for GrWr 34)
 	class LIB_1Rnd_81mm_Mo_HE {
-		LIB_1Rnd_81mm_Mo_HE = 1;
+		LIB_1rnd_81mmHE_GRWR34 = 1;
+	};
+	class LIB_1rnd_81mmHE_GRWR34 {
+		LIB_1rnd_81mmHE_GRWR34 = 1;
+		LIB_8rnd_81mmHE_GRWR34 = 1;
 	};
 	class LIB_1Rnd_81mm_Mo_Smoke {
-		LIB_1Rnd_81mm_Mo_Smoke = 1;
+		LIB_81mm_GRWR34_SmokeShell = 1;
+	};
+	class LIB_81mm_GRWR34_SmokeShell {
+		LIB_81mm_GRWR34_SmokeShell = 1;
 	};
 	class LIB_1Rnd_81mm_Mo_Illum {
 		LIB_1Rnd_81mm_Mo_Illum = 1;
@@ -25,10 +39,17 @@ class ace_csw_groups { // Ammo that can be loaded into CSW's
 
 	///// 60 mm ammo (for M2)
 	class LIB_1Rnd_60mm_Mo_HE {
-		LIB_1Rnd_60mm_Mo_HE = 1;
+		LIB_1rnd_60mmHE_M2 = 1;
+	};
+	class LIB_1rnd_60mmHE_M2 {
+		LIB_1rnd_60mmHE_M2 = 1;
+		LIB_8rnd_60mmHE_M2 = 1;
 	};
 	class LIB_1Rnd_60mm_Mo_Smoke {
-		LIB_1Rnd_60mm_Mo_Smoke = 1;
+		LIB_60mm_M2_SmokeShell = 1;
+	};
+	class LIB_60mm_M2_SmokeShell {
+		LIB_60mm_M2_SmokeShell = 1;
 	};
 	class LIB_1Rnd_60mm_Mo_Illum {
 		LIB_1Rnd_60mm_Mo_Illum = 1;

--- a/addons/mortar/CfgVehicles.hpp
+++ b/addons/mortar/CfgVehicles.hpp
@@ -1,205 +1,83 @@
 class CfgVehicles {
-	class LIB_SU_Mortar_base;
-	class LIB_BM37: LIB_SU_Mortar_base {scope=1;};
-	class LIB_GER_Mortar_base;
-	class LIB_GrWr34: LIB_GER_Mortar_base {scope=1;};
-	class LIB_US_Mortar_base;
-	class LIB_M2_60: LIB_US_Mortar_base {scope=1;};
-
-	class LandVehicle;
-	class StaticWeapon: LandVehicle {
-		class ACE_Actions {
-			class ACE_MainActions;
-		};
+	class LIB_StaticMortar_base;
+	class LIB_SU_Mortar_base: LIB_StaticMortar_base {};
+	class LIB_BM37: LIB_SU_Mortar_base {
+		class UserActions {};
+		class ace_csw {
+			enabled = 1;
+			magazineLocation = "_target selectionPosition 'usti hlavne'";
+			proxyWeapon = "LIB_BM37";
+			disassembleWeapon = "LIB_BM37_Barrel";
+			disassembleTurret = "LIB_BM37_Tripod_Deployed";
+			desiredAmmo = 1;
+			ammoLoadTime = 3;
+			ammoUnloadTime = 5;
+		};	
 	};
-	class StaticMortar: StaticWeapon
-	{
-		class Turrets;
+	class LIB_GER_Mortar_base: LIB_StaticMortar_base {};
+	class LIB_GrWr34: LIB_GER_Mortar_base {
+		class UserActions {};
+		class ace_csw {
+			enabled = 1;
+			magazineLocation = "_target selectionPosition 'usti hlavne'";
+			proxyWeapon = "LIB_GrWr34";
+			disassembleWeapon = "LIB_GrWr34_Barrel"; // carry weapon [CfgWeapons]
+			disassembleTurret = "LIB_GrWr34_Tripod_Deployed"; // turret [CfgVehicles]
+			desiredAmmo = 1; // Ammo count when fully loaded
+			ammoLoadTime = 3; // Time to load ammo in
+			ammoUnloadTime = 5; // Time to retreive ammo from weapon
+		};	
 	};
-	class Mortar_01_base_F: StaticMortar
-	{
-		class EventHandlers;
-		class Turrets: Turrets
-		{
-			class MainTurret;
-		};
-	};
-	class LIB_Mortar_base_ACE: Mortar_01_base_F {
-		scope = 0;
-		expansion = 1;
-		transportSoldier = 1;
-		cargoAction[] = {"LIB_mortar_gunner_2"};
-		mapSize = 3;
-		class Library
-		{
-			libTextDesc = "";
-		};
-		class Eventhandlers: Eventhandlers
-		{
-			class IFA3_Weapons_Static_fnc_fired_EH
-			{
-				fired = "_this call LIB_Weapons_Static_fnc_fired_EH";
-			};
-			class IFA3_Weapons_Static
-			{
-				init = "[(_this select 0),[],true] spawn LIB_Weapons_Static_fnc_init_EH";
-			};
-			class IFA3_Weapons_Static_fnc_GetOut_EH
-			{
-				GetOut = "[(_this select 0),(_this select 1),(_this select 2),'AmovPknlMstpSnonWnonDnon'] call LIB_Weapons_Static_fnc_GetOut_EH";
-			};
-		};
-		class Turrets: Turrets
-		{
-			class MainTurret: MainTurret
-			{
-				weapons[] = {"LIB_GrWr34_ACE"};
-				gunnerAction = "LIB_mortar_gunner_1";
-				discreteDistance[] = {};
-				discreteDistanceInitIndex = 0;
-				gunnerOpticsModel = "\WW2\Assets_m\Vehicles\Optics_m\IF_Optika_Zis3.p3d";
-				gunnerOpticsEffect[] = {"TankGunnerOptics2","OpticsBlur1","OpticsCHAbera1"};
-			};
-		};
-		class assembleInfo
-		{
-			primary = 0;
-			base = "";
-			assembleTo = "";
-			dissasembleTo[] = {};
-			displayName = "";
-		};
-		class ACE_Actions;
+	class LIB_US_Mortar_base: LIB_StaticMortar_base {};
+	class LIB_M2_60: LIB_US_Mortar_base {
+		class UserActions {};
+		class ace_csw {
+			enabled = 1;
+			magazineLocation = "_target selectionPosition 'usti hlavne'";
+			proxyWeapon = "LIB_M2_60_ACE";
+			disassembleWeapon = "LIB_M2_60_Barrel";
+			disassembleTurret = "LIB_M2_60_Tripod_Deployed";
+			desiredAmmo = 1;
+			ammoLoadTime = 3;
+			ammoUnloadTime = 5;
+		};	
 	};
 
-	class LIB_GrWr34_ACE: LIB_Mortar_base_ACE {
-		scope = 2;
-		scopeCurator = 2;
-		side = 1;
-		faction = "LIB_WEHRMACHT";
-		crew = "LIB_GER_gun_crew";
-		typicalCargo[] = {"LIB_GER_gun_crew"};
-		displayName = "$STR_LIB_DN_GRWR34_ACE";
-		model = "\WW2\Assets_m\Weapons\Mortars_m\IF_GrWr34.p3d";
-		icon = "\WW2\Assets_t\Weapons\Icons_t\Mortars\Icon_GrWr34_ca.paa";
-		picture = "\WW2\Assets_t\Vehicles\Pictures_t\LIB_GrWr34_ca.paa";
-		class assembleInfo: assembleInfo
-		{
-			LIB_dissasembleTo[] = {"LIB_GrWr34_Barrel","LIB_GrWr34_Tripod_Deployed"};
-			deployTime = 12;
-		};
-		class Turrets: Turrets
-		{
-			class MainTurret: MainTurret
-			{
-				weapons[] = {"LIB_GrWr34_ACE"};
-				magazines[] = {};
-			};
-		};
-
-		// ACE CSW Compat
-		class ACE_Actions: ACE_Actions
-		{
-			class ACE_MainActions;
-		};
-		class ace_csw
-			{
-				enabled = 1;
-				magazineLocation = "_target selectionPosition 'otochlaven'";
-				proxyWeapon = "LIB_GrWr34_ACE";
-				disassembleWeapon = "LIB_GrWr34_Barrel"; // carry weapon [CfgWeapons]
-				disassembleTurret = "LIB_GrWr34_Tripod_Deployed"; // turret [CfgVehicles]
-				desiredAmmo = 1; // Ammo count when fully loaded
-				ammoLoadTime = 3; // Time to load ammo in
-				ammoUnloadTime = 5; // Time to retreive ammo from weapon
-		};
+	class LIB_GrWr34_ACE: LIB_GrWr34 {
+		scope = 1;
+		// class Turrets: Turrets
+		// {
+			// class MainTurret: MainTurret
+			// {
+				// weapons[] = {"LIB_GrWr34_ACE"};
+				// magazines[] = {};
+			// };
+		// };
 	};
 
-	class LIB_BM37_ACE: LIB_Mortar_base_ACE {
-		scope = 2;
-		scopeCurator = 2;
-		side = 0;
-		faction = "LIB_RKKA";
-		crew = "LIB_SOV_gun_crew";
-		typicalCargo[] = {"LIB_SOV_gun_crew"};
-		displayName = "$STR_LIB_DN_BM37_ACE";
-		model = "\WW2\Assets_m\Weapons\Mortars_m\IF_Bm37.p3d";
-		icon = "\WW2\Assets_t\Weapons\Icons_t\Mortars\Icon_Bm37_ca.paa";
-		picture = "\WW2\Assets_t\Vehicles\Pictures_t\LIB_BM37_ca.paa";
-		class assembleInfo: assembleInfo
-		{
-			LIB_dissasembleTo[] = {"LIB_BM37_Barrel","LIB_BM37_Tripod_Deployed"};
-			deployTime = 13;
-		};
-		class Turrets: Turrets
-		{
-			class MainTurret: MainTurret
-			{
-				weapons[] = {"LIB_BM37_ACE"};
-				magazines[] = {};
-			};
-		};
-
-		// ACE CSW Compat
-		class ACE_Actions: ACE_Actions
-		{
-			class ACE_MainActions;
-		};
-		class ace_csw
-			{
-				enabled = 1;
-				magazineLocation = "_target selectionPosition 'otochlaven'";
-				proxyWeapon = "LIB_BM37_ACE";
-				disassembleWeapon = "LIB_BM37_Barrel"; // carry weapon [CfgWeapons]
-				disassembleTurret = "LIB_BM37_Tripod_Deployed"; // turret [CfgVehicles]
-				desiredAmmo = 1;
-				ammoLoadTime = 3;
-				ammoUnloadTime = 5;
-		};
+	class LIB_BM37_ACE: LIB_BM37 {
+		scope = 1;
+		// class Turrets: Turrets
+		// {
+			// class MainTurret: MainTurret
+			// {
+				// weapons[] = {"LIB_BM37_ACE"};
+				// magazines[] = {};
+			// };
+		// };
 	};
 
-	class LIB_M2_60_ACE: LIB_Mortar_base_ACE {
-		scope = 2;
-		scopeCurator = 2;
-		side = 2;
-		faction = "LIB_US_ARMY";
-		crew = "LIB_US_corporal";
-		typicalCargo[] = {"LIB_US_corporal"};
-		displayName = "$STR_LIB_DN_M2_60_ACE";
-		model = "\WW2\Assets_m\Weapons\Mortars_m\WW2_M2.p3d";
-		icon = "\WW2\Assets_t\Weapons\Icons_t\Mortars\Icon_M2_ca.paa";
-		picture = "\WW2\Assets_t\Vehicles\Pictures_t\LIB_M2_60_ca.paa";
-		class assembleInfo: assembleInfo
-		{
-			LIB_dissasembleTo[] = {"LIB_M2_60_Barrel","LIB_M2_60_Tripod_Deployed"};
-			deployTime = 8;
-		};
-		class Turrets: Turrets
-		{
-			class MainTurret: MainTurret
-			{
-				weapons[] = {"LIB_M2_60_ACE"};
-				magazines[] = {};
-				gunnerOpticsModel = "\WW2\Assets_m\Vehicles\Optics_m\WW2_M4_Mortar_Sight.p3d";
-			};
-		};
-
-		// ACE CSW Compat
-		class ACE_Actions: ACE_Actions
-		{
-			class ACE_MainActions;
-		};
-		class ace_csw
-			{
-				enabled = 1;
-				magazineLocation = "_target selectionPosition 'otochlaven'";
-				proxyWeapon = "LIB_M2_60_ACE";
-				disassembleWeapon = "LIB_M2_60_Barrel"; // carry weapon [CfgWeapons]
-				disassembleTurret = "LIB_M2_60_Tripod_Deployed"; // turret [CfgVehicles]
-				desiredAmmo = 1;
-				ammoLoadTime = 3;
-				ammoUnloadTime = 5;
-		};
+	class LIB_M2_60_ACE: LIB_M2_60 {
+		scope = 1;
+		// class Turrets: Turrets
+		// {
+			// class MainTurret: MainTurret
+			// {
+				// weapons[] = {"LIB_M2_60_ACE"};
+				// magazines[] = {};
+				// gunnerOpticsModel = "\WW2\Assets_m\Vehicles\Optics_m\WW2_M4_Mortar_Sight.p3d";
+			// };
+		// };
 	};
 
 	class B_LIB_AssaultPack_Base;
@@ -210,7 +88,7 @@ class CfgVehicles {
 		class assembleInfo: assembleInfo {
 			class LIB_BM37_Barrel {
 				deployTime = 10;
-				assembleTo = "LIB_BM37_ACE";
+				assembleTo = "LIB_BM37";
 			};
 		};
 		class ace_csw { disassembleTo = "LIB_BM37_Tripod"; }; // What will be spawned when "Pickup Tripod" is selected
@@ -219,7 +97,7 @@ class CfgVehicles {
 		class assembleInfo: assembleInfo {
 			class LIB_GrWr34_Barrel {
 				deployTime = 10;
-				assembleTo = "LIB_GrWr34_ACE";
+				assembleTo = "LIB_GrWr34";
 			};
 		};
 		class ace_csw { disassembleTo = "LIB_GrWr34_Tripod"; }; // What will be spawned when "Pickup Tripod" is selected
@@ -228,7 +106,7 @@ class CfgVehicles {
 		class assembleInfo: assembleInfo {
 			class LIB_M2_60_Barrel {
 				deployTime = 8;
-				assembleTo = "LIB_M2_60_ACE";
+				assembleTo = "LIB_M2_60";
 			};
 		};
 		class ace_csw { disassembleTo = "LIB_M2_60_Tripod"; }; // What will be spawned when "Pickup Tripod" is selected

--- a/addons/mortar/CfgVehicles.hpp
+++ b/addons/mortar/CfgVehicles.hpp
@@ -34,7 +34,7 @@ class CfgVehicles {
 		class ace_csw {
 			enabled = 1;
 			magazineLocation = "_target selectionPosition 'usti hlavne'";
-			proxyWeapon = "LIB_M2_60_ACE";
+			proxyWeapon = "LIB_M2_60";
 			disassembleWeapon = "LIB_M2_60_Barrel";
 			disassembleTurret = "LIB_M2_60_Tripod_Deployed";
 			desiredAmmo = 1;

--- a/addons/mortar/CfgVehicles.hpp
+++ b/addons/mortar/CfgVehicles.hpp
@@ -43,42 +43,9 @@ class CfgVehicles {
 		};	
 	};
 
-	class LIB_GrWr34_ACE: LIB_GrWr34 {
-		scope = 1;
-		// class Turrets: Turrets
-		// {
-			// class MainTurret: MainTurret
-			// {
-				// weapons[] = {"LIB_GrWr34_ACE"};
-				// magazines[] = {};
-			// };
-		// };
-	};
-
-	class LIB_BM37_ACE: LIB_BM37 {
-		scope = 1;
-		// class Turrets: Turrets
-		// {
-			// class MainTurret: MainTurret
-			// {
-				// weapons[] = {"LIB_BM37_ACE"};
-				// magazines[] = {};
-			// };
-		// };
-	};
-
-	class LIB_M2_60_ACE: LIB_M2_60 {
-		scope = 1;
-		// class Turrets: Turrets
-		// {
-			// class MainTurret: MainTurret
-			// {
-				// weapons[] = {"LIB_M2_60_ACE"};
-				// magazines[] = {};
-				// gunnerOpticsModel = "\WW2\Assets_m\Vehicles\Optics_m\WW2_M4_Mortar_Sight.p3d";
-			// };
-		// };
-	};
+	class LIB_GrWr34_ACE: LIB_GrWr34 {scope = 1;};
+	class LIB_BM37_ACE: LIB_BM37 {scope = 1;};
+	class LIB_M2_60_ACE: LIB_M2_60 {scope = 1;};
 
 	class B_LIB_AssaultPack_Base;
 	class LIB_Tripod_Bag: B_LIB_AssaultPack_Base {

--- a/addons/mortar/CfgVehicles.hpp
+++ b/addons/mortar/CfgVehicles.hpp
@@ -1,81 +1,159 @@
 class CfgVehicles {
-	class LIB_StaticMortar_base;
+	class LandVehicle;
+	class StaticWeapon: LandVehicle {
+			class ACE_Actions {
+					class ACE_MainActions;
+			};
+	};
+	class StaticMortar: StaticWeapon
+	{
+		class Eventhandlers;
+	};
+	class LIB_StaticMortar_base: StaticMortar
+	{
+		class EventHandlers: EventHandlers
+		{
+			class IFA3_Weapons_Static
+			{
+				init = "";
+			};
+			class LIB_StaticWeaponsHandler
+			{
+				init = "";
+			};
+		};
+	};
 	class LIB_SU_Mortar_base: LIB_StaticMortar_base {};
 	class LIB_BM37: LIB_SU_Mortar_base {
-		class UserActions {};
+		class ACE_Actions: ACE_Actions {
+				class ACE_MainActions: ACE_MainActions {
+						position = "";
+						selection = "gunnerview";
+				};
+		};
+		class UserActions {
+			delete Reload;
+			delete Prepare_HE_Selected;
+			delete Prepare_Smoke_Selected;
+			delete Prepare_Smoke;
+			delete Prepare_HE;
+			delete Unload;
+		};
 		class ace_csw {
 			enabled = 1;
 			magazineLocation = "_target selectionPosition 'usti hlavne'";
 			proxyWeapon = "LIB_BM37";
 			disassembleWeapon = "LIB_BM37_Barrel";
-			disassembleTurret = "LIB_BM37_Tripod_Deployed";
+			disassembleTurret = "ACE_LIB_BM37_Tripod_Deployed";
 			desiredAmmo = 1;
 			ammoLoadTime = 3;
 			ammoUnloadTime = 5;
-		};	
+		};
 	};
 	class LIB_GER_Mortar_base: LIB_StaticMortar_base {};
 	class LIB_GrWr34: LIB_GER_Mortar_base {
-		class UserActions {};
+		class ACE_Actions: ACE_Actions {
+				class ACE_MainActions: ACE_MainActions {
+						position = "";
+						selection = "gunnerview";
+				};
+		};
+		class UserActions {
+			delete Reload;
+			delete Prepare_HE_Selected;
+			delete Prepare_Smoke_Selected;
+			delete Prepare_Smoke;
+			delete Prepare_HE;
+			delete Unload;
+		};
 		class ace_csw {
 			enabled = 1;
 			magazineLocation = "_target selectionPosition 'usti hlavne'";
 			proxyWeapon = "LIB_GrWr34";
 			disassembleWeapon = "LIB_GrWr34_Barrel"; // carry weapon [CfgWeapons]
-			disassembleTurret = "LIB_GrWr34_Tripod_Deployed"; // turret [CfgVehicles]
+			disassembleTurret = "ACE_LIB_GrWr34_Tripod_Deployed"; // turret [CfgVehicles]
 			desiredAmmo = 1; // Ammo count when fully loaded
 			ammoLoadTime = 3; // Time to load ammo in
 			ammoUnloadTime = 5; // Time to retreive ammo from weapon
-		};	
+		};
 	};
 	class LIB_US_Mortar_base: LIB_StaticMortar_base {};
 	class LIB_M2_60: LIB_US_Mortar_base {
-		class UserActions {};
+		class ACE_Actions: ACE_Actions {
+				class ACE_MainActions: ACE_MainActions {
+						position = "";
+						selection = "gunnerview";
+				};
+		};
+		class UserActions {
+			delete Reload;
+			delete Prepare_HE_Selected;
+			delete Prepare_Smoke_Selected;
+			delete Prepare_WP_Selected;
+			delete Prepare_WP;
+			delete Prepare_Smoke;
+			delete Prepare_HE;
+			delete Unload;
+		};
 		class ace_csw {
 			enabled = 1;
 			magazineLocation = "_target selectionPosition 'usti hlavne'";
 			proxyWeapon = "LIB_M2_60";
 			disassembleWeapon = "LIB_M2_60_Barrel";
-			disassembleTurret = "LIB_M2_60_Tripod_Deployed";
+			disassembleTurret = "ACE_LIB_M2_60_Tripod_Deployed";
 			desiredAmmo = 1;
 			ammoLoadTime = 3;
 			ammoUnloadTime = 5;
-		};	
+		};
 	};
 
 	class LIB_GrWr34_ACE: LIB_GrWr34 {scope = 1;};
 	class LIB_BM37_ACE: LIB_BM37 {scope = 1;};
 	class LIB_M2_60_ACE: LIB_M2_60 {scope = 1;};
 
-	class B_LIB_AssaultPack_Base;
-	class LIB_Tripod_Bag: B_LIB_AssaultPack_Base {
-		class assembleInfo;
-	};
-	class LIB_BM37_Tripod_Deployed: LIB_Tripod_Bag {
-		class assembleInfo: assembleInfo {
-			class LIB_BM37_Barrel {
-				deployTime = 10;
-				assembleTo = "LIB_BM37";
-			};
+	class ThingX;
+	class ace_csw_baseTripod: ThingX {
+		class ACE_Actions {
+				class ACE_MainActions {};
 		};
+	};
+	class ACE_LIB_BM37_Tripod_Deployed: ace_csw_baseTripod {
+		class ACE_Actions: ACE_Actions {
+				class ACE_MainActions: ACE_MainActions {
+					displayName = "$STR_DN_LIB_BM37_TRI";
+				};
+		};
+		author = "AWAR";
+		scope = 2;
+		displayName = "$STR_DN_LIB_BM37_TRI";
+		model = "\WW2\Assets_m\Weapons\Mortars_m\IF_Bm37_Disas.p3d";
+		picture = "\WW2\Assets_t\Weapons\Equipment_t\Weapons\Launchers\Gear_BM37_Tripod_X_ca.paa";
 		class ace_csw { disassembleTo = "LIB_BM37_Tripod"; }; // What will be spawned when "Pickup Tripod" is selected
 	};
-	class LIB_GrWr34_Tripod_Deployed: LIB_Tripod_Bag {
-		class assembleInfo: assembleInfo {
-			class LIB_GrWr34_Barrel {
-				deployTime = 10;
-				assembleTo = "LIB_GrWr34";
-			};
+	class ACE_LIB_GrWr34_Tripod_Deployed: ace_csw_baseTripod {
+		class ACE_Actions: ACE_Actions {
+				class ACE_MainActions: ACE_MainActions {
+					displayName = "$STR_DN_LIB_GRWR34_TRI";
+				};
 		};
+		author = "AWAR";
+		scope = 2;
+		displayName = "$STR_DN_LIB_GRWR34_TRI";
+		picture = "\WW2\Assets_t\Weapons\Equipment_t\Weapons\Launchers\Gear_GrWr34_Tripod_X_ca.paa";
+		model = "\WW2\Assets_m\Weapons\Mortars_m\IF_GrWr34_Disas.p3d";
 		class ace_csw { disassembleTo = "LIB_GrWr34_Tripod"; }; // What will be spawned when "Pickup Tripod" is selected
 	};
-	class LIB_M2_60_Tripod_Deployed: LIB_Tripod_Bag {
-		class assembleInfo: assembleInfo {
-			class LIB_M2_60_Barrel {
-				deployTime = 8;
-				assembleTo = "LIB_M2_60";
-			};
+	class ACE_LIB_M2_60_Tripod_Deployed: ace_csw_baseTripod {
+		class ACE_Actions: ACE_Actions {
+				class ACE_MainActions: ACE_MainActions {
+					displayName = "$STR_DN_LIB_M2_60_TRI";
+				};
 		};
+		author = "IFA3 Team";
+		scope = 2;
+		displayName = "$STR_DN_LIB_M2_60_TRI";
+		picture = "\WW2\Assets_t\Weapons\Equipment_t\Weapons\Launchers\Gear_M2_Tripod_X_ca.paa";
+		model = "\WW2\Assets_m\Weapons\Mortars_m\WW2_M2_Disas.p3d";
 		class ace_csw { disassembleTo = "LIB_M2_60_Tripod"; }; // What will be spawned when "Pickup Tripod" is selected
 	};
 

--- a/addons/mortar/CfgWeapons.hpp
+++ b/addons/mortar/CfgWeapons.hpp
@@ -1,13 +1,11 @@
 class CfgWeapons
 {
 	class CannonCore;
-	class mortar_82mm: CannonCore {
+	class LIB_MortarCannon_base: CannonCore {
 		class Single1;
 	};
 
-	class LIB_BM37_ACE: mortar_82mm {
-		author = "IFA3 Team";
-		displayname = "$STR_DN_LIB_BM37";
+	class LIB_BM37: LIB_MortarCannon_base {
 		magazines[] = {"LIB_1Rnd_82mm_Mo_HE","LIB_1Rnd_82mm_Mo_Smoke","LIB_1Rnd_82mm_Mo_Illum"};
 		modes[] = {"Single1","Single2","Single3"};
 		reloadTime = 0.5;
@@ -17,9 +15,7 @@ class CfgWeapons
 		};
 	};
 
-	class LIB_GrWr34_ACE: mortar_82mm {
-		author = "IFA3 Team";
-		displayname = "$STR_DN_LIB_GRWR34";
+	class LIB_GRWR34: LIB_MortarCannon_base {
 		magazines[] = {"LIB_1Rnd_81mm_Mo_HE","LIB_1Rnd_81mm_Mo_Smoke","LIB_1Rnd_81mm_Mo_Illum"};
 		modes[] = {"Single1","Single2","Single3"};
 		reloadTime = 0.5;
@@ -29,11 +25,9 @@ class CfgWeapons
 		};
 	};
 
-	class LIB_M2_60_ACE: mortar_82mm {
-		author = "IFA3 Team";
-		displayname = "$STR_DN_LIB_M2_60";
+	class LIB_M2_60: LIB_MortarCannon_base {
 		magazines[] = {"LIB_1Rnd_60mm_Mo_HE","LIB_1Rnd_60mm_Mo_Smoke","LIB_1Rnd_60mm_Mo_Illum"};
-		modes[] = {"Single1","Single2"};
+		modes[] = {"Single1","Single2","Single3"};
 		reloadTime = 0.5;
 		magazineReloadTime = 0.5;
 		class Single1: Single1 {
@@ -42,14 +36,8 @@ class CfgWeapons
 	};
 
 	class LIB_Slung_Static_Weapon_Base;
-
-
-	////// BM 37 82mm
 	class LIB_BM37_Tripod: LIB_Slung_Static_Weapon_Base {
-		// Assigning the mortar ammo as magazine makes them show up as ammo in the arsenal, but ammo in the slots will get deleted upon weapon assembly
-		magazines[] = {"LIB_1Rnd_82mm_Mo_HE","LIB_1Rnd_82mm_Mo_Smoke","LIB_1Rnd_82mm_Mo_Illum"};
-
-		// ACE CSW Compat
+		magazines[] = {"LIB_1Rnd_82mm_Mo_HE","LIB_1Rnd_82mm_Mo_Smoke","LIB_1Rnd_82mm_Mo_Illum"}; // Assigning the mortar ammo as magazine makes them show up as ammo in the arsenal, but ammo in the slots will get deleted upon weapon assembly
 		class ACE_CSW {
 			type = "mount"; // What type of carry it is. Must always be "mount" for the tripod
 			deployTime = 4; // How long it takes to deploy the tripod
@@ -58,74 +46,55 @@ class CfgWeapons
 		};
 	};
 	class LIB_BM37_Barrel: LIB_Slung_Static_Weapon_Base {
-		// Assigning the mortar ammo as magazine makes them show up as ammo in the arsenal, but ammo in the slots will get deleted upon weapon assembly
 		magazines[] = {"LIB_1Rnd_82mm_Mo_HE","LIB_1Rnd_82mm_Mo_Smoke","LIB_1Rnd_82mm_Mo_Illum"};
-
-		// ACE CSW Compat
 		class ACE_CSW {
-			type = "weapon"; // What type of carry it is. Must always be "weapon" for the carry weapon
-			deployTime = 4; // How long it takes to deploy the weapon onto the tripod
-			pickupTime = 4; // How long it takes to disassemble weapon from the tripod
+			type = "weapon"; // What type of carry it is. Must always be "weapon" for the weapon
+			deployTime = 4;
+			pickupTime = 4;
 			class assembleTo {
-					LIB_BM37_Tripod_Deployed = "LIB_BM37_ACE";
+					LIB_BM37_Tripod_Deployed = "LIB_BM37";
 			};
 		};
 	};
 
-
-	////// GrWr 34 81mm
 	class LIB_GrWr34_Tripod: LIB_Slung_Static_Weapon_Base {
-		// Assigning the mortar ammo as magazine makes them show up as ammo in the arsenal, but ammo in the slots will get deleted upon weapon assembly
 		magazines[] = {"LIB_1Rnd_81mm_Mo_HE","LIB_1Rnd_81mm_Mo_Smoke","LIB_1Rnd_81mm_Mo_Illum"};
-
-		// ACE CSW Compat
 		class ACE_CSW {
-			type = "mount"; // What type of carry it is. Must always be "mount" for the tripod
-			deployTime = 4; // How long it takes to deploy the tripod
-			pickupTime = 4; // How long it takes to pickup the tripod
-			deploy = "LIB_GrWr34_Tripod_Deployed"; // what vehicle will spawn when the tripod is deployed
+			type = "mount";
+			deployTime = 4;
+			pickupTime = 4;
+			deploy = "LIB_GrWr34_Tripod_Deployed";
 		};
 	};
 	class LIB_GrWr34_Barrel: LIB_Slung_Static_Weapon_Base {
-		// Assigning the mortar ammo as magazine makes them show up as ammo in the arsenal, but ammo in the slots will get deleted upon weapon assembly
 		magazines[] = {"LIB_1Rnd_81mm_Mo_HE","LIB_1Rnd_81mm_Mo_Smoke","LIB_1Rnd_81mm_Mo_Illum"};
-
-		// ACE CSW Compat
 		class ACE_CSW {
-			type = "weapon"; // What type of carry it is. Must always be "weapon" for the carry weapon
-			deployTime = 4; // How long it takes to deploy the weapon onto the tripod
-			pickupTime = 4; // How long it takes to disassemble weapon from the tripod
+			type = "weapon";
+			deployTime = 4;
+			pickupTime = 4;
 			class assembleTo {
 					LIB_GrWr34_Tripod_Deployed = "LIB_GrWr34_ACE";
 			};
 		};
 	};
 
-
-	////// M2 60mm
 	class LIB_M2_60_Tripod: LIB_Slung_Static_Weapon_Base {
-		// Assigning the mortar ammo as magazine makes them show up as ammo in the arsenal, but ammo in the slots will get deleted upon weapon assembly
 		magazines[] = {"LIB_1Rnd_60mm_Mo_HE","LIB_1Rnd_60mm_Mo_Smoke","LIB_1Rnd_60mm_Mo_Illum"};
-
-		// ACE CSW Compat
 		class ACE_CSW {
-			type = "mount"; // What type of carry it is. Must always be "mount" for the tripod
-			deployTime = 4; // How long it takes to deploy the tripod
-			pickupTime = 4; // How long it takes to pickup the tripod
-			deploy = "LIB_M2_60_Tripod_Deployed"; // what vehicle will spawn when the tripod is deployed
+			type = "mount";
+			deployTime = 4;
+			pickupTime = 4;
+			deploy = "LIB_M2_60_Tripod_Deployed";
 		};
 	};
 	class LIB_M2_60_Barrel: LIB_Slung_Static_Weapon_Base {
-		// Assigning the mortar ammo as magazine makes them show up as ammo in the arsenal, but ammo in the slots will get deleted upon weapon assembly
 		magazines[] = {"LIB_1Rnd_60mm_Mo_HE","LIB_1Rnd_60mm_Mo_Smoke","LIB_1Rnd_60mm_Mo_Illum"};
-
-		// ACE CSW Compat
 		class ACE_CSW {
-			type = "weapon"; // What type of carry it is. Must always be "weapon" for the carry weapon
-			deployTime = 4; // How long it takes to deploy the weapon onto the tripod
-			pickupTime = 4; // How long it takes to disassemble weapon from the tripod
+			type = "weapon";
+			deployTime = 4;
+			pickupTime = 4;
 			class assembleTo {
-					LIB_M2_60_Tripod_Deployed = "LIB_M2_60_ACE";
+					LIB_M2_60_Tripod_Deployed = "LIB_M2_60";
 			};
 		};
 	};

--- a/addons/mortar/CfgWeapons.hpp
+++ b/addons/mortar/CfgWeapons.hpp
@@ -6,95 +6,89 @@ class CfgWeapons
 	};
 
 	class LIB_BM37: LIB_MortarCannon_base {
-		magazines[] = {"LIB_1Rnd_82mm_Mo_HE","LIB_1Rnd_82mm_Mo_Smoke","LIB_1Rnd_82mm_Mo_Illum"};
+		magazines[] += {"LIB_1Rnd_82mm_Mo_Illum"};
 		modes[] = {"Single1","Single2","Single3"};
 		reloadTime = 0.5;
 		magazineReloadTime = 0.5;
-		class Single1: Single1 {
-			reloadTime = 0.5;
-		};
 	};
 
 	class LIB_GRWR34: LIB_MortarCannon_base {
-		magazines[] = {"LIB_1Rnd_81mm_Mo_HE","LIB_1Rnd_81mm_Mo_Smoke","LIB_1Rnd_81mm_Mo_Illum"};
+		magazines[] += {"LIB_1Rnd_81mm_Mo_Illum"};
 		modes[] = {"Single1","Single2","Single3"};
 		reloadTime = 0.5;
 		magazineReloadTime = 0.5;
-		class Single1: Single1 {
-			reloadTime = 0.5;
-		};
 	};
 
 	class LIB_M2_60: LIB_MortarCannon_base {
-		magazines[] = {"LIB_1Rnd_60mm_Mo_HE","LIB_1Rnd_60mm_Mo_Smoke","LIB_1Rnd_60mm_Mo_Illum"};
+		magazines[] += {"LIB_1Rnd_60mm_Mo_Illum"};
 		modes[] = {"Single1","Single2","Single3"};
 		reloadTime = 0.5;
 		magazineReloadTime = 0.5;
-		class Single1: Single1 {
-			reloadTime = 0.5;
-		};
 	};
 
 	class LIB_Slung_Static_Weapon_Base;
 	class LIB_BM37_Tripod: LIB_Slung_Static_Weapon_Base {
-		magazines[] = {"LIB_1Rnd_82mm_Mo_HE","LIB_1Rnd_82mm_Mo_Smoke","LIB_1Rnd_82mm_Mo_Illum"}; // Assigning the mortar ammo as magazine makes them show up as ammo in the arsenal, but ammo in the slots will get deleted upon weapon assembly
+		LIB_isTripod = 0;
+		magazines[] += {"LIB_1Rnd_82mm_Mo_Illum"}; // Assigning the mortar ammo as magazine makes them show up as ammo in the arsenal, but ammo in the slots will get deleted upon weapon assembly
 		class ACE_CSW {
 			type = "mount"; // What type of carry it is. Must always be "mount" for the tripod
 			deployTime = 4; // How long it takes to deploy the tripod
 			pickupTime = 4; // How long it takes to pickup the tripod
-			deploy = "LIB_BM37_Tripod_Deployed"; // what vehicle will spawn when the tripod is deployed
+			deploy = "ACE_LIB_GrWr34_Tripod_Deployed"; // what vehicle will spawn when the tripod is deployed
 		};
 	};
 	class LIB_BM37_Barrel: LIB_Slung_Static_Weapon_Base {
-		magazines[] = {"LIB_1Rnd_82mm_Mo_HE","LIB_1Rnd_82mm_Mo_Smoke","LIB_1Rnd_82mm_Mo_Illum"};
+		magazines[] += {"LIB_1Rnd_82mm_Mo_Illum"};
 		class ACE_CSW {
 			type = "weapon"; // What type of carry it is. Must always be "weapon" for the weapon
 			deployTime = 4;
 			pickupTime = 4;
 			class assembleTo {
-					LIB_BM37_Tripod_Deployed = "LIB_BM37";
+					ACE_LIB_GrWr34_Tripod_Deployed = "LIB_BM37";
 			};
 		};
 	};
 
 	class LIB_GrWr34_Tripod: LIB_Slung_Static_Weapon_Base {
-		magazines[] = {"LIB_1Rnd_81mm_Mo_HE","LIB_1Rnd_81mm_Mo_Smoke","LIB_1Rnd_81mm_Mo_Illum"};
+		LIB_isTripod = 0;
+		magazines[] += {"LIB_1Rnd_81mm_Mo_Illum"};
 		class ACE_CSW {
 			type = "mount";
 			deployTime = 4;
 			pickupTime = 4;
-			deploy = "LIB_GrWr34_Tripod_Deployed";
+			deploy = "ACE_LIB_GrWr34_Tripod_Deployed";
 		};
 	};
 	class LIB_GrWr34_Barrel: LIB_Slung_Static_Weapon_Base {
-		magazines[] = {"LIB_1Rnd_81mm_Mo_HE","LIB_1Rnd_81mm_Mo_Smoke","LIB_1Rnd_81mm_Mo_Illum"};
+		magazines[] += {"LIB_1Rnd_81mm_Mo_Illum"};
 		class ACE_CSW {
 			type = "weapon";
 			deployTime = 4;
 			pickupTime = 4;
 			class assembleTo {
-					LIB_GrWr34_Tripod_Deployed = "LIB_GrWr34_ACE";
+					ACE_LIB_GrWr34_Tripod_Deployed = "LIB_GrWr34";
 			};
 		};
 	};
 
 	class LIB_M2_60_Tripod: LIB_Slung_Static_Weapon_Base {
-		magazines[] = {"LIB_1Rnd_60mm_Mo_HE","LIB_1Rnd_60mm_Mo_Smoke","LIB_1Rnd_60mm_Mo_Illum"};
+		LIB_isTripod = 0;
+		magazines[] += {"LIB_1Rnd_60mm_Mo_Illum"};
 		class ACE_CSW {
 			type = "mount";
 			deployTime = 4;
 			pickupTime = 4;
-			deploy = "LIB_M2_60_Tripod_Deployed";
+			deploy = "ACE_LIB_M2_60_Tripod_Deployed";
 		};
 	};
 	class LIB_M2_60_Barrel: LIB_Slung_Static_Weapon_Base {
-		magazines[] = {"LIB_1Rnd_60mm_Mo_HE","LIB_1Rnd_60mm_Mo_Smoke","LIB_1Rnd_60mm_Mo_Illum"};
+		magazines[] += {"LIB_1Rnd_60mm_Mo_Illum"};
 		class ACE_CSW {
 			type = "weapon";
 			deployTime = 4;
 			pickupTime = 4;
 			class assembleTo {
-					LIB_M2_60_Tripod_Deployed = "LIB_M2_60";
+					ACE_LIB_M2_60_Tripod_Deployed = "LIB_M2_60";
 			};
 		};
 	};

--- a/addons/mortar/Extended_PreStart_EventHandlers.hpp
+++ b/addons/mortar/Extended_PreStart_EventHandlers.hpp
@@ -1,7 +1,7 @@
-class Extended_PreStart_EventHandlers
-{
-	class ace_mk6mortar
-	{
-		init = "call compile preProcessFileLineNumbers '\z\ace\addons\mk6mortar\XEH_preStart.sqf'";
-	};
-};
+// class Extended_PreStart_EventHandlers
+// {
+// 	class ace_mk6mortar
+// 	{
+// 		init = "call compile preProcessFileLineNumbers '\z\ace\addons\mk6mortar\XEH_preStart.sqf'";
+// 	};
+// };

--- a/addons/mortar/cfgMagazines.hpp
+++ b/addons/mortar/cfgMagazines.hpp
@@ -1,22 +1,45 @@
 class CfgMagazines
 {
+	class 8Rnd_82mm_Mo_Smoke_white;
 	class ACE_1Rnd_82mm_Mo_HE;
 	class ACE_1Rnd_82mm_Mo_Smoke;
 	class ACE_1Rnd_82mm_Mo_Illum;
-	class LIB_1Rnd_82mm_Mo_HE: ACE_1Rnd_82mm_Mo_HE
+	class LIB_8Rnd_82mmHE_BM37;
+	class LIB_8Rnd_81mmHE_GRWR34;
+	class LIB_8Rnd_60mmHE_M2;
+	class LIB_1rnd_82mmHE_BM37: LIB_8Rnd_82mmHE_BM37
 	{
-		model = "\WW2\Assets_m\Weapons\Ammoboxes_m\mortars\WW2_shell80.p3d";
-		hiddenSelections[] = {"camo1"};
-		hiddenSelectionsTextures[] = {"WW2\Assets_t\Weapons\Ammoboxes_t\WW2_Mortars\shell80_he_co.paa"};
-		picture = "\WW2\Assets_t\Weapons\Equipment_t\Magazines\Mortars\M_80_HE_ca.paa";
-		ammo = "LIB_Sh_82_HE";
+		ace_arsenal_hide = -1;
 	};
-	class LIB_1Rnd_82mm_Mo_Smoke: ACE_1Rnd_82mm_Mo_Smoke
+	class LIB_82mm_BM37_SmokeShell: 8Rnd_82mm_Mo_Smoke_white
 	{
-		model = "\WW2\Assets_m\Weapons\Ammoboxes_m\mortars\WW2_shell80.p3d";
-		hiddenSelections[] = {"camo1"};
-		hiddenSelectionsTextures[] = {"WW2\Assets_t\Weapons\Ammoboxes_t\WW2_Mortars\shell80_smoke_co.paa"};
-		picture = "\WW2\Assets_t\Weapons\Equipment_t\Magazines\Mortars\M_80_Smoke_ca.paa";
+		ace_arsenal_hide = -1;
+	};
+	class LIB_1rnd_81mmHE_GRWR34: LIB_8Rnd_81mmHE_GRWR34
+	{
+		ace_arsenal_hide = -1;
+	};
+	class LIB_81mm_GRWR34_SmokeShell: 8Rnd_82mm_Mo_Smoke_white
+	{
+		ace_arsenal_hide = -1;
+	};
+	class LIB_1rnd_60mmHE_M2: LIB_8Rnd_60mmHE_M2
+	{
+		ace_arsenal_hide = -1;
+	};
+	class LIB_60mm_M2_SmokeShell: 8Rnd_82mm_Mo_Smoke_white
+	{
+		ace_arsenal_hide = -1;
+	};
+	class LIB_1Rnd_82mm_Mo_HE: LIB_1rnd_82mmHE_BM37
+	{
+		ace_arsenal_hide = 1;
+		scope = 1;
+	};
+	class LIB_1Rnd_82mm_Mo_Smoke: LIB_82mm_BM37_SmokeShell
+	{
+		ace_arsenal_hide = 1;
+		scope = 1;
 	};
 	class LIB_1Rnd_82mm_Mo_Illum: ACE_1Rnd_82mm_Mo_Illum
 	{
@@ -25,22 +48,15 @@ class CfgMagazines
 		hiddenSelectionsTextures[] = {"WW2\Assets_t\Weapons\Ammoboxes_t\WW2_Mortars\shell80_illum_co.paa"};
 		picture = "\WW2\Assets_t\Weapons\Equipment_t\Magazines\Mortars\M_80_Illum_ca.paa";
 	};
-	class LIB_1Rnd_81mm_Mo_HE: ACE_1Rnd_82mm_Mo_HE
+	class LIB_1Rnd_81mm_Mo_HE: LIB_1rnd_81mmHE_GRWR34
 	{
-		displayName = "$STR_ACE_81mm_magazine_HE_displayName";
-		model = "\WW2\Assets_m\Weapons\Ammoboxes_m\mortars\WW2_shell80.p3d";
-		hiddenSelections[] = {"camo1"};
-		hiddenSelectionsTextures[] = {"WW2\Assets_t\Weapons\Ammoboxes_t\WW2_Mortars\shell80_he_co.paa"};
-		picture = "\WW2\Assets_t\Weapons\Equipment_t\Magazines\Mortars\M_80_HE_ca.paa";
-		ammo = "LIB_Sh_81_HE";
+		ace_arsenal_hide = 1;
+		scope = 1;
 	};
-	class LIB_1Rnd_81mm_Mo_Smoke: ACE_1Rnd_82mm_Mo_Smoke
+	class LIB_1Rnd_81mm_Mo_Smoke: LIB_81mm_GRWR34_SmokeShell
 	{
-		displayName = "$STR_ACE_81mm_magazine_Smoke_displayName";
-		model = "\WW2\Assets_m\Weapons\Ammoboxes_m\mortars\WW2_shell80.p3d";
-		hiddenSelections[] = {"camo1"};
-		hiddenSelectionsTextures[] = {"WW2\Assets_t\Weapons\Ammoboxes_t\WW2_Mortars\shell80_smoke_co.paa"};
-		picture = "\WW2\Assets_t\Weapons\Equipment_t\Magazines\Mortars\M_80_Smoke_ca.paa";
+		ace_arsenal_hide = 1;
+		scope = 1;
 	};
 	class LIB_1Rnd_81mm_Mo_Illum: ACE_1Rnd_82mm_Mo_Illum
 	{
@@ -50,24 +66,15 @@ class CfgMagazines
 		hiddenSelectionsTextures[] = {"WW2\Assets_t\Weapons\Ammoboxes_t\WW2_Mortars\shell80_illum_co.paa"};
 		picture = "\WW2\Assets_t\Weapons\Equipment_t\Magazines\Mortars\M_80_Illum_ca.paa";
 	};
-	class LIB_1Rnd_60mm_Mo_HE: ACE_1Rnd_82mm_Mo_HE
+	class LIB_1Rnd_60mm_Mo_HE: LIB_1rnd_60mmHE_M2
 	{
-		displayName = "$STR_ACE_60mm_magazine_HE_displayName";
-		model = "\WW2\Assets_m\Weapons\Ammoboxes_m\mortars\WW2_shell60.p3d";
-		hiddenSelections[] = {"camo1"};
-		hiddenSelectionsTextures[] = {"WW2\Assets_t\Weapons\Ammoboxes_t\WW2_Mortars\shell60_he_co.paa"};
-		picture = "\WW2\Assets_t\Weapons\Equipment_t\Magazines\Mortars\M_60_HE_ca.paa";
-		ammo = "LIB_Sh_60_HE";
-		mass = 30;
+		ace_arsenal_hide = 1;
+		scope = 1;
 	};
-	class LIB_1Rnd_60mm_Mo_Smoke: ACE_1Rnd_82mm_Mo_Smoke
+	class LIB_1Rnd_60mm_Mo_Smoke: LIB_60mm_M2_SmokeShell
 	{
-		displayName = "$STR_ACE_60mm_magazine_Smoke_displayName";
-		model = "\WW2\Assets_m\Weapons\Ammoboxes_m\mortars\WW2_shell60.p3d";
-		hiddenSelections[] = {"camo1"};
-		hiddenSelectionsTextures[] = {"WW2\Assets_t\Weapons\Ammoboxes_t\WW2_Mortars\shell60_smoke_co.paa"};
-		picture = "\WW2\Assets_t\Weapons\Equipment_t\Magazines\Mortars\M_60_Smoke_ca.paa";
-		mass = 30;
+		ace_arsenal_hide = 1;
+		scope = 1;
 	};
 	class LIB_1Rnd_60mm_Mo_Illum: ACE_1Rnd_82mm_Mo_Illum
 	{

--- a/addons/mortar/config.cpp
+++ b/addons/mortar/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
         units[] = {"LIB_GrWr34_ACE","LIB_BM37_ACE","LIB_M2_60_ACE"};
         weapons[] = {"LIB_BM37_ACE","LIB_GrWr34_ACE","LIB_M2_60_ACE"};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"A3_Weapons_F","A3_Static_F","LIB_weapons","ace_interaction","ace_mk6mortar","WW2_Assets_c_Vehicles_StaticWeapons_c","WW2_Assets_c_Weapons_Ammoboxes_c"};
+        requiredAddons[] = {"A3_Weapons_F","A3_Static_F","LIB_weapons","ace_interaction","ace_mk6mortar","WW2_Assets_c_Vehicles_StaticWeapons_c","WW2_Assets_c_Vehicles_Weapons_c","WW2_Assets_c_Weapons_Ammoboxes_c"};
         author = CSTRING(Team);
         authors[] = { "WOG", "El Tyranos" };
         authorUrl = CSTRING(Url);


### PR DESCRIPTION
**Don't merge yet - this PR is for co-working**

TODO : 
- [x] Get rid of inherited UserActions
- [x] ACE ammo handling does not work
- [x] Check https://github.com/bux/IFA3_ACE_COMPAT/issues/49
- [x] Confirm https://github.com/bux/IFA3_ACE_COMPAT/issues/51 is gone

Notes:
* It uses ACE CSW entirely for assembly/disassembly so don't do it like vanilla IFA3, you need to use self-interact to deploy the tripod, and interact with it to assemble.

Known issues:
* If you place a mortar down in the editor you wont be able to disassemble it unless 'advanced assembly' is enabled, and doing so will probably break AI as it makes all the stored ammo appear next to the mortar.